### PR TITLE
ASDAS: Add upper limits for CRP and ESR

### DIFF
--- a/docs/source/tasks/asdas.rst
+++ b/docs/source/tasks/asdas.rst
@@ -54,7 +54,9 @@ Each question is weighted:
 Intellectual property rights
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-**TO BE ESTABLISHED**
+**TO BE ESTABLISHED.** Original paper (Lukas et al. 2009) is copyright 2009 BMJ
+Publishing Group and European League Against Rheumatism, but status of task
+itself less clear.
 
 
 History

--- a/server/camcops_server/tasks/asdas.py
+++ b/server/camcops_server/tasks/asdas.py
@@ -205,6 +205,8 @@ class Asdas(TaskHasPatientMixin,
         if crp is None:
             return None
 
+        crp = max(crp, 2.0)
+
         return (
             0.12 * self.back_pain() +
             0.06 * self.morning_stiffness() +
@@ -283,7 +285,8 @@ class Asdas(TaskHasPatientMixin,
                     0.11 × patient global +
                     0.07 × peripheral pain +
                     0.58 × ln(CRP + 1).
-                    CRP units: mg/L.<br>
+                    CRP units: mg/L. When CRP<2mg/L, use 2mg/L to calculate
+                    ASDAS-CRP.<br>
                 [3] 0.08 x back pain +
                     0.07 x duration of morning stiffness +
                     0.11 x patient global +

--- a/server/camcops_server/tasks/asdas.py
+++ b/server/camcops_server/tasks/asdas.py
@@ -285,7 +285,7 @@ class Asdas(TaskHasPatientMixin,
                     0.11 × patient global +
                     0.07 × peripheral pain +
                     0.58 × ln(CRP + 1).
-                    CRP units: mg/L. When CRP<2mg/L, use 2mg/L to calculate
+                    CRP units: mg/L. When CRP&lt;2mg/L, use 2mg/L to calculate
                     ASDAS-CRP.<br>
                 [3] 0.08 x back pain +
                     0.07 x duration of morning stiffness +

--- a/tablet_qt/tasks/asdas.cpp
+++ b/tablet_qt/tasks/asdas.cpp
@@ -150,24 +150,24 @@ double Asdas::peripheralPain() const
 
 QVariant Asdas::asdasCrp() const
 {
-    QVariant crp = value(Q_CRP);
+    const QVariant crp = value(Q_CRP);
     if (crp.isNull()) {
         return QVariant();
     }
 
-    double adjustedCrp = std::max(crp.toDouble(), 2.0);
+    const double adjusted_crp = std::max(crp.toDouble(), 2.0);
 
     return 0.12 * backPain() +
         0.06 * morningStiffness() +
         0.11 * patientGlobal() +
         0.07 * peripheralPain() +
-        0.58 * std::log(adjustedCrp + 1);
+        0.58 * std::log(adjusted_crp + 1);
 }
 
 
 QVariant Asdas::asdasEsr() const
 {
-    QVariant esr = value(Q_ESR);
+    const QVariant esr = value(Q_ESR);
     if (esr.isNull()) {
         return QVariant();
     }

--- a/tablet_qt/tasks/asdas.cpp
+++ b/tablet_qt/tasks/asdas.cpp
@@ -155,11 +155,13 @@ QVariant Asdas::asdasCrp() const
         return QVariant();
     }
 
+    double adjustedCrp = std::max(crp.toDouble(), 2.0);
+
     return 0.12 * backPain() +
         0.06 * morningStiffness() +
         0.11 * patientGlobal() +
         0.07 * peripheralPain() +
-        0.58 * std::log(crp.toDouble() + 1);
+        0.58 * std::log(adjustedCrp + 1);
 }
 
 

--- a/tablet_qt/tasks/asdas.cpp
+++ b/tablet_qt/tasks/asdas.cpp
@@ -45,6 +45,8 @@ const QString QPREFIX("q");
 const QString Q_CRP("q5");
 const QString Q_ESR("q6");
 
+const double CRP_MAX = 2000;
+const double ESR_MAX = 300;
 const int CRP_ESR_DP = 2;
 
 const QString Asdas::ASDAS_TABLENAME("asdas");
@@ -288,20 +290,16 @@ OpenableWidget* Asdas::editor(const bool read_only)
 
     page->addElement(crp_esr_inst);
 
-    const QString crp_esr_hint(tr("real number, %1 dp").arg(CRP_ESR_DP));
-
     page->addElement(new QuText(xstring(Q_CRP)));
     const auto crp_field = new QuLineEditDouble(
-        fieldRef(Q_CRP), 0, std::numeric_limits<double>::max(), CRP_ESR_DP
+        fieldRef(Q_CRP), 0, CRP_MAX, CRP_ESR_DP
     );
-    crp_field->setHint(crp_esr_hint);
     page->addElement(crp_field);
 
     page->addElement(new QuText(xstring(Q_ESR)));
     const auto esr_field = new QuLineEditDouble(
-        fieldRef(Q_ESR), 0, std::numeric_limits<double>::max(), CRP_ESR_DP
+        fieldRef(Q_ESR), 0, ESR_MAX, CRP_ESR_DP
     );
-    esr_field->setHint(crp_esr_hint);
     page->addElement(esr_field);
 
     connect(fieldRef(Q_CRP).data(), &FieldRef::valueChanged,


### PR DESCRIPTION
CRP <= 2000, ESR <= 300 should cover all anticipated values
The means we no longer need the custom hint

@RudolfCardinal We're only enforcing this on the client side. Does that seem reasonable? Could easily add validators on the server side. Do we need to care about a minimum value for CRP? https://www.asas-group.org/clinical-instruments/asdas-calculator/ has a minimum of 2.0mg/L. We could do the same or leave it to the discretion of the clinician.
