### PR TITLE
Minor doc fix for the Windows x86_32 Qt setup

### DIFF
--- a/docs/source/developer/building_client.rst
+++ b/docs/source/developer/building_client.rst
@@ -738,9 +738,9 @@ Non-default options are marked in bold and/or as "[non-default]".
         * - Qt mkspec
           -
         * - CMake Tool
-          -
-        * - CMake Generator
           - **System CMake at** ``C:\Program Files (x86)\CMake\bin\cmake.exe``
+        * - CMake Generator
+          -
         * - CMake Configuration
           - ``CMAKE_CXX_COMPILER:STRING=%{Compiler:Executable:Cxx}``
             ``CMAKE_C_COMPILER:STRING=%{Compiler:Executable:C}``


### PR DESCRIPTION
This change puts the CMake Tool on the right line