### PR TITLE
Remove typing - part of standard library now

### DIFF
--- a/server/setup.py
+++ b/server/setup.py
@@ -130,7 +130,6 @@ INSTALL_REQUIRES = [
     'tornado<6',  # used indirectly by Celery; v6+ breaks; see
     # https://github.com/jupyter/notebook/issues/4311
 
-    'typing==3.6.4',  # part of stdlib in python 3.5, but not 3.4
     'Wand==0.4.4',  # ImageMagick binding
 ]
 


### PR DESCRIPTION
Python 3.4 has reached EOL so we no longer need to support typing as a third party library