### PR TITLE
Fix inheritance of MOJO task table

### DIFF
--- a/server/camcops_server/camcops_server_core.py
+++ b/server/camcops_server/camcops_server_core.py
@@ -114,7 +114,7 @@ from camcops_server.cc_modules.cc_taskindex import (
     check_indexes,
     reindex_everything,
 )  # nopep8
-from camcops_server.cc_modules.cc_tracker import TrackerCtvTests
+from camcops_server.cc_modules.cc_tracker import TrackerCtvTests  # noqa
 from camcops_server.cc_modules.cc_unittest import (
     DemoDatabaseTestCase,
     DemoRequestTestCase,

--- a/server/camcops_server/camcops_server_core.py
+++ b/server/camcops_server/camcops_server_core.py
@@ -114,6 +114,7 @@ from camcops_server.cc_modules.cc_taskindex import (
     check_indexes,
     reindex_everything,
 )  # nopep8
+from camcops_server.cc_modules.cc_tracker import TrackerCtvTests
 from camcops_server.cc_modules.cc_unittest import (
     DemoDatabaseTestCase,
     DemoRequestTestCase,

--- a/server/camcops_server/camcops_server_core.py
+++ b/server/camcops_server/camcops_server_core.py
@@ -128,6 +128,7 @@ from camcops_server.cc_modules.celery import (
     CELERY_APP_NAME,
     CELERY_SOFT_TIME_LIMIT_SEC,
 )  # nopep8
+from camcops_server.cc_modules.webview import WebviewTests  # noqa
 
 log.info("Imports complete")
 log.info("Using {} tasks", len(Task.all_subclasses_by_tablename()))
@@ -736,11 +737,11 @@ def check_index(cfg: CamcopsConfig, show_all_bad: bool = False) -> bool:
 def launch_celery_workers(verbose: bool = False) -> None:
     """
     Launch Celery workers.
-    
+
     See also advice in
-    
+
     - https://medium.com/@taylorhughes/three-quick-tips-from-two-years-with-celery-c05ff9d7f9eb
-    
+
     - Re ``-Ofair``:
       http://docs.celeryproject.org/en/latest/userguide/optimizing.html
 

--- a/server/camcops_server/cc_modules/cc_tracker.py
+++ b/server/camcops_server/cc_modules/cc_tracker.py
@@ -49,7 +49,10 @@ from camcops_server.cc_modules.cc_filename import get_export_filename
 from camcops_server.cc_modules.cc_plot import matplotlib
 from camcops_server.cc_modules.cc_pdf import pdf_from_html
 from camcops_server.cc_modules.cc_pyramid import ViewArg, ViewParam
-from camcops_server.cc_modules.cc_simpleobjects import TaskExportOptions
+from camcops_server.cc_modules.cc_simpleobjects import (
+    IdNumReference,
+    TaskExportOptions,
+)
 from camcops_server.cc_modules.cc_task import Task
 from camcops_server.cc_modules.cc_taskcollection import (
     TaskCollection,
@@ -799,14 +802,23 @@ class TrackerCtvTests(DemoDatabaseTestCase):
     """
     Unit tests.
     """
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.taskfilter = TaskFilter()
+
+        idnum_ref = IdNumReference(which_idnum=0, idnum_value=0)
+
+        self.taskfilter.idnum_criteria = [idnum_ref]
+        self.taskfilter.tasks_with_patient_only = True
+
     def test_tracker(self) -> None:
         self.announce("test_tracker")
         req = self.req
-        taskfilter = TaskFilter()
-        t = Tracker(req, taskfilter)
+        t = Tracker(req, self.taskfilter)
 
         self.assertIsInstance(t.get_html(), str)
-        self.assertIsInstance(t.get_pdf(), str)
+        self.assertIsInstance(t.get_pdf(), bytes)
         self.assertIsInstance(t.get_pdf_html(), str)
         self.assertIsInstance(t.get_xml(), str)
         self.assertIsInstance(t.suggested_pdf_filename(), str)
@@ -814,11 +826,10 @@ class TrackerCtvTests(DemoDatabaseTestCase):
     def test_ctv(self) -> None:
         self.announce("test_ctv")
         req = self.req
-        taskfilter = TaskFilter()
-        c = ClinicalTextView(req, taskfilter)
+        c = ClinicalTextView(req, self.taskfilter)
 
         self.assertIsInstance(c.get_html(), str)
-        self.assertIsInstance(c.get_pdf(), str)
+        self.assertIsInstance(c.get_pdf(), bytes)
         self.assertIsInstance(c.get_pdf_html(), str)
         self.assertIsInstance(c.get_xml(), str)
         self.assertIsInstance(c.suggested_pdf_filename(), str)

--- a/server/camcops_server/cc_modules/webview.py
+++ b/server/camcops_server/cc_modules/webview.py
@@ -126,6 +126,7 @@ import logging
 import os
 # from pprint import pformat
 from typing import Any, Dict, List, Tuple, Type, TYPE_CHECKING
+import unittest
 
 from cardinal_pythonlib.datetimefunc import format_datetime
 from cardinal_pythonlib.deform_utils import get_head_form_html
@@ -282,6 +283,7 @@ from camcops_server.cc_modules.cc_taskfilter import (
 from camcops_server.cc_modules.cc_taskindex import update_indexes_and_push_exports  # noqa
 from camcops_server.cc_modules.cc_text import SS
 from camcops_server.cc_modules.cc_tracker import ClinicalTextView, Tracker
+from camcops_server.cc_modules.cc_unittest import DemoDatabaseTestCase
 from camcops_server.cc_modules.cc_user import (
     SecurityAccountLockout,
     SecurityLoginFailure,
@@ -3445,3 +3447,32 @@ def static_bugfix_deform_missing_glyphs(req: "CamcopsRequest") -> Response:
     Hack for a missing-file bug in ``deform==2.0.4``.
     """
     return FileResponse(DEFORM_MISSING_GLYPH, request=req)
+
+
+# =============================================================================
+# Unit testing
+# =============================================================================
+
+class WebviewTests(DemoDatabaseTestCase):
+    """
+    Unit tests.
+    """
+    def test_any_records_use_group_true(self):
+        # All tasks created in DemoDatabaseTestCase will be in this group
+        self.announce("test_any_records_use_group_true")
+        self.assertTrue(any_records_use_group(self.req, self.group))
+
+    def test_any_records_use_group_false(self):
+        """
+        If this fails with:
+        sqlalchemy.exc.InvalidRequestError: SQL expression, column, or mapped
+        entity expected - got <name of task base class>
+        then the base class probably needs to be declared __abstract__. See
+        DiagnosisItemBase as an example.
+        """
+        self.announce("test_any_records_use_group_false")
+        group = Group()
+        self.dbsession.add(self.group)
+        self.dbsession.flush()
+
+        self.assertFalse(any_records_use_group(self.req, group))

--- a/server/camcops_server/tasks/khandaker_mojo_medicationtherapy.py
+++ b/server/camcops_server/tasks/khandaker_mojo_medicationtherapy.py
@@ -49,7 +49,9 @@ if TYPE_CHECKING:
     from camcops_server.cc_modules.cc_request import CamcopsRequest
 
 
-class KhandakerMojoTableItem(GenericTabletRecordMixin, TaskDescendant):
+class KhandakerMojoTableItem(GenericTabletRecordMixin, Base):
+    __abstract__ = True
+
     def any_fields_none(self) -> bool:
         for f in self.mandatory_fields():
             if getattr(self, f) is None:
@@ -83,7 +85,7 @@ class KhandakerMojoTableItem(GenericTabletRecordMixin, TaskDescendant):
             self.medicationtable_id, self)
 
 
-class KhandakerMojoMedicationItem(KhandakerMojoTableItem, Base):
+class KhandakerMojoMedicationItem(KhandakerMojoTableItem, TaskDescendant):
     __tablename__ = "khandaker_mojo_medication_item"
 
     medicationtable_id = CamcopsColumn(
@@ -152,7 +154,7 @@ class KhandakerMojoMedicationItem(KhandakerMojoTableItem, Base):
         """
 
 
-class KhandakerMojoTherapyItem(KhandakerMojoTableItem, Base):
+class KhandakerMojoTherapyItem(KhandakerMojoTableItem, TaskDescendant):
     __tablename__ = "khandaker_mojo_therapy_item"
 
     medicationtable_id = CamcopsColumn(

--- a/server/camcops_server/tasks/khandaker_mojo_medicationtherapy.py
+++ b/server/camcops_server/tasks/khandaker_mojo_medicationtherapy.py
@@ -49,7 +49,7 @@ if TYPE_CHECKING:
     from camcops_server.cc_modules.cc_request import CamcopsRequest
 
 
-class KhandakerMojoTableItem(GenericTabletRecordMixin, Base):
+class KhandakerMojoTableItem(GenericTabletRecordMixin, TaskDescendant, Base):
     __abstract__ = True
 
     def any_fields_none(self) -> bool:
@@ -85,7 +85,7 @@ class KhandakerMojoTableItem(GenericTabletRecordMixin, Base):
             self.medicationtable_id, self)
 
 
-class KhandakerMojoMedicationItem(KhandakerMojoTableItem, TaskDescendant):
+class KhandakerMojoMedicationItem(KhandakerMojoTableItem):
     __tablename__ = "khandaker_mojo_medication_item"
 
     medicationtable_id = CamcopsColumn(
@@ -154,7 +154,7 @@ class KhandakerMojoMedicationItem(KhandakerMojoTableItem, TaskDescendant):
         """
 
 
-class KhandakerMojoTherapyItem(KhandakerMojoTableItem, TaskDescendant):
+class KhandakerMojoTherapyItem(KhandakerMojoTableItem):
     __tablename__ = "khandaker_mojo_therapy_item"
 
     medicationtable_id = CamcopsColumn(

--- a/tablet_qt/tasks/khandakermojosociodemographics.cpp
+++ b/tablet_qt/tasks/khandakermojosociodemographics.cpp
@@ -181,6 +181,8 @@ OpenableWidget* KhandakerMojoSociodemographics::editor(const bool read_only)
                 this, &KhandakerMojoSociodemographics::updateMandatory);
 
         QuMcq* mcq = new QuMcq(fieldref, getOptions(info));
+        mcq->setHorizontal(true);
+        mcq->setAsTextButton(true);
         page->addElement(mcq);
 
         if (info.hasOther()) {


### PR DESCRIPTION
This was failing when deleting a group. 

```
File "/home/rudolf/Documents/code/camcops/server/camcops_server/cc_modules/webview.py", line 2610, in delete_group
*    if any_records_use_group(req, group):*
  File "/home/rudolf/Documents/code/camcops/server/camcops_server/cc_modules/webview.py", line 2584, in any_records_use_group
*    q = **CountStarSpecializedQuery**(cls, session=dbsession)\*
  File "/home/rudolf/dev/venvs/camcops/lib/python3.6/site-packages/cardinal_pythonlib/sqlalchemy/orm_query.py", line 200, in __init__
    super().__init__(*args, **kwargs)
  File "/home/rudolf/dev/venvs/camcops/lib/python3.6/site-packages/sqlalchemy/orm/query.py", line 168, in __init__
    self._set_entities(entities)
  File "/home/rudolf/dev/venvs/camcops/lib/python3.6/site-packages/sqlalchemy/orm/query.py", line 198, in _set_entities
    entity_wrapper(self, ent)
  File "/home/rudolf/dev/venvs/camcops/lib/python3.6/site-packages/sqlalchemy/orm/query.py", line 4466, in __init__
    "expected - got '%r'" % (column,)
sqlalchemy.exc.InvalidRequestError: SQL expression, column, or mapped entity expected - got '<class 'camcops_server.tasks.khandaker_mojo_medicationtherapy.KhandakerMojoTableItem'>'
```


Also add test to check for other badly coded task classes

