### PR TITLE
Make page picker and NVP dialogues size to content properly

### DIFF
--- a/server/camcops_server/tasks/khandaker_mojo_medicationtherapy.py
+++ b/server/camcops_server/tasks/khandaker_mojo_medicationtherapy.py
@@ -25,6 +25,7 @@ camcops_server/tasks/khandaker_mojo_medicationtherapy.py
 ===============================================================================
 
 """
+
 from typing import List, Optional, Type, TYPE_CHECKING
 
 from sqlalchemy.sql.sqltypes import Float, Integer, UnicodeText

--- a/tablet_qt/dialogs/nvpchoicedialog.cpp
+++ b/tablet_qt/dialogs/nvpchoicedialog.cpp
@@ -76,7 +76,6 @@ int NvpChoiceDialog::choose(QVariant* new_value)
     const QVariant old_value = *m_p_new_value;
 
     m_resized_to_contents = false;
-    // setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 
     auto contentwidget = new QWidget();  // doesn't need to be BaseWidget; contains scroll area
     auto contentlayout = new VBoxLayout();

--- a/tablet_qt/dialogs/nvpchoicedialog.h
+++ b/tablet_qt/dialogs/nvpchoicedialog.h
@@ -25,6 +25,7 @@
 #include "lib/uifunc.h"
 #include "questionnairelib/namevalueoptions.h"
 
+class QShowEvent;
 class QVariant;
 
 
@@ -62,4 +63,5 @@ protected:
     QString m_icon_filename;
     QSize m_icon_size;
     QVariant* m_p_new_value;
+    bool m_resized_to_contents;
 };

--- a/tablet_qt/dialogs/pagepickerdialog.cpp
+++ b/tablet_qt/dialogs/pagepickerdialog.cpp
@@ -17,8 +17,11 @@
     along with CamCOPS. If not, see <http://www.gnu.org/licenses/>.
 */
 
+// #define DEBUG_PRESS_A_TO_ADJUST_SIZE
+// #define DEBUG_PRESS_D_TO_DUMP_LAYOUT
+
 #include "pagepickerdialog.h"
-#include <functional>
+#include <functional>  // for std::bind
 #include <QDialogButtonBox>
 #include <QEvent>
 #include <QVBoxLayout>
@@ -29,6 +32,14 @@
 #include "widgets/imagebutton.h"
 #include "widgets/verticalscrollarea.h"
 
+#if defined DEBUG_PRESS_A_TO_ADJUST_SIZE || defined DEBUG_PRESS_D_TO_DUMP_LAYOUT
+    #include "qobjects/keypresswatcher.h"
+#endif
+#ifdef DEBUG_PRESS_D_TO_DUMP_LAYOUT
+    #include "lib/layoutdumper.h"
+    const layoutdumper::DumperConfig dumper_config;
+#endif
+
 
 PagePickerDialog::PagePickerDialog(QWidget* parent,
                                    const PagePickerItemList& pages,
@@ -36,7 +47,8 @@ PagePickerDialog::PagePickerDialog(QWidget* parent,
     QDialog(parent),
     m_pages(pages),
     m_title(title),
-    m_new_page_number(nullptr)
+    m_new_page_number(nullptr),
+    m_resized_to_contents(false)
 {
 }
 
@@ -49,6 +61,7 @@ int PagePickerDialog::choose(int* new_page_number)
     m_new_page_number = new_page_number;
     setWindowTitle(m_title);
     setMinimumSize(uifunc::minimumSizeForTitle(this));
+    // setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 
     auto contentwidget = new QWidget();  // doesn't need to be BaseWidget; contains scroll area
     auto contentlayout = new VBoxLayout();
@@ -88,6 +101,24 @@ int PagePickerDialog::choose(int* new_page_number)
             this, &PagePickerDialog::reject);
     mainlayout->addWidget(standard_buttons);
 
+#if defined DEBUG_PRESS_A_TO_ADJUST_SIZE || defined DEBUG_PRESS_D_TO_DUMP_LAYOUT
+    auto keywatcher = new KeyPressWatcher(this);
+#endif
+#ifdef DEBUG_PRESS_A_TO_ADJUST_SIZE
+    keywatcher->addKeyEvent(
+        Qt::Key_A,
+        std::bind(&QWidget::adjustSize, this));
+#endif
+#ifdef DEBUG_PRESS_D_TO_DUMP_LAYOUT
+    // keywatcher becomes child of this,
+    // and layoutdumper is a namespace, so:
+    // Safe object lifespan signal: can use std::bind
+    keywatcher->addKeyEvent(
+        Qt::Key_D,
+        std::bind(&layoutdumper::dumpWidgetHierarchy, this, dumper_config));
+#endif
+
+    m_resized_to_contents = false;
     return exec();
 }
 
@@ -113,10 +144,15 @@ void PagePickerDialog::itemClicked(const int item_index)
 
 bool PagePickerDialog::event(QEvent* e)
 {
+    // See NvpChoiceDialog::event().
+
     const bool result = QDialog::event(e);
     const QEvent::Type type = e->type();
-    if (type == QEvent::Type::Show) {
-        adjustSize();
+    if (type == QEvent::Type::WindowActivate) {
+        if (!m_resized_to_contents) {  // do this once only:
+            adjustSize();
+            m_resized_to_contents = true;
+        }
     }
     return result;
 }

--- a/tablet_qt/dialogs/pagepickerdialog.cpp
+++ b/tablet_qt/dialogs/pagepickerdialog.cpp
@@ -61,7 +61,6 @@ int PagePickerDialog::choose(int* new_page_number)
     m_new_page_number = new_page_number;
     setWindowTitle(m_title);
     setMinimumSize(uifunc::minimumSizeForTitle(this));
-    // setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 
     auto contentwidget = new QWidget();  // doesn't need to be BaseWidget; contains scroll area
     auto contentlayout = new VBoxLayout();

--- a/tablet_qt/dialogs/pagepickerdialog.h
+++ b/tablet_qt/dialogs/pagepickerdialog.h
@@ -50,4 +50,5 @@ protected:
     PagePickerItemList m_pages;
     QString m_title;
     int* m_new_page_number;
+    bool m_resized_to_contents;
 };


### PR DESCRIPTION
Uses QEvent::Type::WindowActivate for a one-off call to adjustSize().
Makes the "choose page" and "choose option" (name/value pair picker) dialogues stop clipping their contents annoyingly.