### PR TITLE
Debugging code for crash in QMediaPlayer() ?via gstreamer

### DIFF
--- a/tablet_qt/lib/soundfunc.cpp
+++ b/tablet_qt/lib/soundfunc.cpp
@@ -35,12 +35,14 @@ void makeMediaPlayer(QSharedPointer<QMediaPlayer>& player)
     // qDebug() << "Default QMediaPlayer() flags: " << static_cast<int>(QMediaPlayer::Flags());
     // default "flags" argument to QMediaPlayer() is 0, i.e. no flags set.
 
+    qDebug() << "About to call QMediaPlayer()...";
     player = QSharedPointer<QMediaPlayer>(new QMediaPlayer(),
                                           &QObject::deleteLater);
     // http://doc.qt.io/qt-5/qsharedpointer.html
     // Failing to use deleteLater() can cause crashes, as there may be
     // outstanding events relating to this object.
     // ... but it's not enough; see finishMediaPlayer().
+    qDebug() << "... QMediaPlayer() has returned.";
 
     /*
 


### PR DESCRIPTION
Martin -- if you run the 3D ID/ID task, do you get a crash (or v. long pause) in soundfunc.cpp, when it calls QMediaPlayer()? A stack dump is in the comments in that file. I think this might be machine-specific (and has possibly gone wrong since an OS upgrade); looks like it relates to gstreamer. Am a bit stuck so if you have any insights that'd be great :) This branch just adds some warning code so the cause is more apparent when it goes wrong. It looks like it calls into video code; I don't know if it's possible to say "this media player is for sound only", which might conceivably help...?