### PR TITLE
Don't try to reindex during migrations

### DIFF
--- a/server/camcops_server/alembic/versions/0013_task_index.py
+++ b/server/camcops_server/alembic/versions/0013_task_index.py
@@ -114,13 +114,6 @@ def upgrade():
 
     # ### end Alembic commands ###
 
-    if not context.is_offline_mode():
-        # Offline mode means "print SQL only". So we only execute the following
-        # in online ("talk to the database") mode:
-        cfg = get_default_config_from_os_env()
-        with cfg.get_dbsession_context() as dbsession:
-            reindex_everything(dbsession, skip_tasks_with_missing_tables=True)
-
 
 # noinspection PyPep8,PyTypeChecker
 def downgrade():

--- a/server/camcops_server/camcops_server.py
+++ b/server/camcops_server/camcops_server.py
@@ -185,8 +185,6 @@ def _downgrade_database_to_revision(
         revision=revision,
         show_sql_only=show_sql_only,
         confirm_downgrade_db=confirm_downgrade_db)
-    if not show_sql_only:
-        log.warning("You should run the 'reindex' command.")
 
 
 def _create_database_from_scratch(cfg: "CamcopsConfig") -> None:

--- a/server/camcops_server/cc_modules/cc_alembic.py
+++ b/server/camcops_server/cc_modules/cc_alembic.py
@@ -60,6 +60,8 @@ if TYPE_CHECKING:
 
 log = BraceStyleAdapter(logging.getLogger(__name__))
 
+REINDEX_WARNING_MESSAGE = "You should run the 'reindex' command."
+
 
 def import_all_models():
     """
@@ -100,6 +102,8 @@ def upgrade_database_to_revision(revision: str,
                      as_sql=show_sql_only)
     # ... will get its config information from the OS environment; see
     # run_alembic() in alembic/env.py
+    if not show_sql_only:
+        log.warning(REINDEX_WARNING_MESSAGE)
 
 
 def downgrade_database_to_revision(revision: str,
@@ -128,6 +132,8 @@ def downgrade_database_to_revision(revision: str,
                        as_sql=show_sql_only)
     # ... will get its config information from the OS environment; see
     # run_alembic() in alembic/env.py
+    if not show_sql_only:
+        log.warning(REINDEX_WARNING_MESSAGE)
 
 
 @preserve_cwd

--- a/server/camcops_server/cc_modules/cc_alembic.py
+++ b/server/camcops_server/cc_modules/cc_alembic.py
@@ -60,8 +60,6 @@ if TYPE_CHECKING:
 
 log = BraceStyleAdapter(logging.getLogger(__name__))
 
-REINDEX_WARNING_MESSAGE = "You should run the 'reindex' command."
-
 
 def import_all_models():
     """
@@ -102,8 +100,6 @@ def upgrade_database_to_revision(revision: str,
                      as_sql=show_sql_only)
     # ... will get its config information from the OS environment; see
     # run_alembic() in alembic/env.py
-    if not show_sql_only:
-        log.warning(REINDEX_WARNING_MESSAGE)
 
 
 def downgrade_database_to_revision(revision: str,
@@ -132,8 +128,6 @@ def downgrade_database_to_revision(revision: str,
                        as_sql=show_sql_only)
     # ... will get its config information from the OS environment; see
     # run_alembic() in alembic/env.py
-    if not show_sql_only:
-        log.warning(REINDEX_WARNING_MESSAGE)
 
 
 @preserve_cwd


### PR DESCRIPTION
@RudolfCardinal I'm not sure if you were thinking the warning should go in migration 0013 in place of the call to `reindex_everything` or once the database upgrade was complete. I've opted for the latter as I think the message will otherwise be lost in the noise.
