### PR TITLE
Fix undefined extra_msg in password templates

### DIFF
--- a/server/camcops_server/cc_modules/webview.py
+++ b/server/camcops_server/cc_modules/webview.py
@@ -722,7 +722,6 @@ def change_own_password(req: "CamcopsRequest") -> Response:
     assert user is not None
     expired = user.must_change_password
     form = ChangeOwnPasswordForm(request=req, must_differ=True)
-    extra_msg = ""
     if FormAction.SUBMIT in req.POST:
         try:
             controls = list(req.POST.items())
@@ -743,7 +742,6 @@ def change_own_password(req: "CamcopsRequest") -> Response:
         "change_own_password.mako",
         dict(form=rendered_form,
              expired=expired,
-             extra_msg=extra_msg,
              min_pw_length=MINIMUM_PASSWORD_LENGTH,
              head_form_html=get_head_form_html(req, [form])),
         request=req)

--- a/server/camcops_server/templates/menu/change_other_password.mako
+++ b/server/camcops_server/templates/menu/change_other_password.mako
@@ -32,10 +32,6 @@ camcops_server/templates/menu/change_other_password.mako
 
 <h1>${_("Change password for user:")} ${username}</h1>
 
-%if extra_msg:
-    <div class="warning">${extra_msg}</div>
-%endif
-
 ${form}
 
 <div>


### PR DESCRIPTION
`extra_msg` is not defined in `change_other_password.mako`. It is passed into
`change_own_password.mako` (as empty string) but isn't used. Assuming it is OK
to remove this in both places.
