### PR TITLE
APEQ CPFT Perinatal Report

### DIFF
--- a/server/camcops_server/alembic/versions/0013_task_index.py
+++ b/server/camcops_server/alembic/versions/0013_task_index.py
@@ -38,11 +38,10 @@ Creation date: 2018-11-10 22:54:18.529528
 # Imports
 # =============================================================================
 
-from alembic import context, op
+from alembic import op
 import sqlalchemy as sa
 from camcops_server.cc_modules.cc_config import get_default_config_from_os_env
 import camcops_server.cc_modules.cc_sqla_coltypes
-from camcops_server.cc_modules.cc_taskindex import reindex_everything
 
 
 # =============================================================================

--- a/server/camcops_server/camcops_server_core.py
+++ b/server/camcops_server/camcops_server_core.py
@@ -114,7 +114,8 @@ from camcops_server.cc_modules.cc_taskindex import (
     check_indexes,
     reindex_everything,
 )  # nopep8
-from camcops_server.cc_modules.cc_tracker import TrackerCtvTests  # noqa
+# noinspection PyUnresolvedReferences
+from camcops_server.cc_modules.cc_tracker import TrackerCtvTests  # import side effects (register unit test)  # nopep8
 from camcops_server.cc_modules.cc_unittest import (
     DemoDatabaseTestCase,
     DemoRequestTestCase,
@@ -129,7 +130,8 @@ from camcops_server.cc_modules.celery import (
     CELERY_APP_NAME,
     CELERY_SOFT_TIME_LIMIT_SEC,
 )  # nopep8
-from camcops_server.cc_modules.webview import WebviewTests  # noqa
+# noinspection PyUnresolvedReferences
+from camcops_server.cc_modules.webview import WebviewTests  # import side effects (register unit test)  # nopep8
 
 log.info("Imports complete")
 log.info("Using {} tasks", len(Task.all_subclasses_by_tablename()))

--- a/server/camcops_server/cc_modules/cc_db.py
+++ b/server/camcops_server/cc_modules/cc_db.py
@@ -1022,7 +1022,7 @@ def add_multiple_columns(
     for n in range(start, end + 1):
         nstr = str(n)
         i = n - start
-        colname = prefix + nstr
+        colname = prefix + nstr + suffix
         if comment_fmt:
             s = ""
             if 0 <= i < len(comment_strings):

--- a/server/camcops_server/cc_modules/cc_report.py
+++ b/server/camcops_server/cc_modules/cc_report.py
@@ -280,7 +280,7 @@ class Report(object):
             plain_report = self.get_rows_colnames(req)
             if plain_report is None:
                 raise NotImplementedError(
-                    "Report did not implement either of get_select_statement()"
+                    "Report did not implement either of get_query()"
                     " or get_rows_colnames()")
             column_names = plain_report.column_names
             rows = plain_report.rows

--- a/server/camcops_server/cc_modules/cc_taskindex.py
+++ b/server/camcops_server/cc_modules/cc_taskindex.py
@@ -693,6 +693,7 @@ class TaskIndexEntry(Base):
                 an SQLAlchemy Session
         """
 
+        # noinspection PyUnresolvedReferences
         idxtable = cls.__table__  # type: Table
         idxcols = idxtable.columns
         tasktablename = task.__class__.tablename

--- a/server/camcops_server/cc_modules/cc_unittest.py
+++ b/server/camcops_server/cc_modules/cc_unittest.py
@@ -47,6 +47,7 @@ from camcops_server.cc_modules.cc_version import CAMCOPS_SERVER_VERSION
 
 if TYPE_CHECKING:
     from camcops_server.cc_modules.cc_db import GenericTabletRecordMixin
+    from camcops_server.cc_modules.cc_patient import Patient
     from camcops_server.cc_modules.cc_task import Task
 
 log = BraceStyleAdapter(logging.getLogger(__name__))
@@ -177,7 +178,7 @@ class DemoDatabaseTestCase(DemoRequestTestCase):
 
         self.create_tasks()
 
-    def create_patient_with_two_idnums(self):
+    def create_patient_with_two_idnums(self) -> "Patient":
         from camcops_server.cc_modules.cc_patient import Patient
         from camcops_server.cc_modules.cc_patientidnum import PatientIdNum
         # Populate database with two of everything
@@ -206,7 +207,7 @@ class DemoDatabaseTestCase(DemoRequestTestCase):
 
         return patient
 
-    def create_patient_with_one_idnum(self):
+    def create_patient_with_one_idnum(self) -> "Patient":
         from camcops_server.cc_modules.cc_patient import Patient
         from camcops_server.cc_modules.cc_patientidnum import PatientIdNum
         patient = Patient()
@@ -227,7 +228,7 @@ class DemoDatabaseTestCase(DemoRequestTestCase):
 
         return patient
 
-    def create_tasks(self):
+    def create_tasks(self) -> None:
         from camcops_server.cc_modules.cc_blob import Blob
         from camcops_server.tasks.photo import Photo
         from camcops_server.cc_modules.cc_task import Task

--- a/server/camcops_server/tasks/apeq_cpft_perinatal.py
+++ b/server/camcops_server/tasks/apeq_cpft_perinatal.py
@@ -28,11 +28,17 @@ camcops_server/tasks/apeq_cpft_perinatal.py
 
 from typing import Dict, List, Optional
 
+from cardinal_pythonlib.classes import classproperty
+
+from pyramid.renderers import render_to_response
+from pyramid.response import Response
+from sqlalchemy.sql.expression import and_, column, func, select
 from sqlalchemy.sql.schema import Column
 from sqlalchemy.sql.sqltypes import Integer, UnicodeText
 
 from camcops_server.cc_modules.cc_constants import CssClass
 from camcops_server.cc_modules.cc_html import tr_qa
+from camcops_server.cc_modules.cc_report import Report
 from camcops_server.cc_modules.cc_request import CamcopsRequest
 from camcops_server.cc_modules.cc_task import Task
 
@@ -138,3 +144,181 @@ class APEQCPFTPerinatal(Task):
                        self.comments or "")}
             </table>
         """
+
+    def get_ff_options(self, req: "CamcopsRequest") -> List[str]:
+        options = []
+
+        for n in range(0, 5 + 1):
+            options.append(self.wxstring(req, f"ff_a{n}"))
+
+        return options
+
+
+# =============================================================================
+# Reports
+# =============================================================================
+
+class APEQCPFTPerinatalReport(Report):
+    """
+    Provides a summary of each question, x% of people said each response etc.
+    Then a summary of the comments.
+    """
+    def __init__(self):
+        super().__init__()
+
+        self.task = APEQCPFTPerinatal()
+
+    @classproperty
+    def report_id(cls) -> str:
+        return "apeq_cpft_perinatal"
+
+    @classmethod
+    def title(cls, req: "CamcopsRequest") -> str:
+        _ = req.gettext
+        return _("APEQ CPFT Perinatal — Question summaries")
+
+    @classproperty
+    def superuser_only(cls) -> bool:
+        return False
+
+    def get_response(self, req: "CamcopsRequest") -> Response:
+        return render_to_response(
+            "apeq_cpft_perinatal_report.mako",
+            dict(
+                title=self.title(req),
+                report_id=self.report_id,
+                main_column_headings=self._get_main_column_headings(req),
+                main_rows=self._get_main_rows(req),
+                ff_column_headings=self._get_ff_column_headings(req),
+                ff_rows=self._get_ff_rows(req),
+                ff_why_rows=self._get_ff_why_rows(req),
+                comments=self._get_comments(req)
+            ),
+            request=req
+        )
+
+    def _get_main_column_headings(self, req: "CamcopsRequest") -> List[str]:
+        _ = req.gettext
+        names = [_("Question")]
+
+        for n in range(0, 2 + 1):
+            names.append(self.task.wxstring(req, f"main_a{n}"))
+
+        return names
+
+    def _get_main_rows(self, req: "CamcopsRequest") -> List[str]:
+        """
+        Percentage of people who answered x for each question
+        """
+        column_dict = {}
+
+        qnums = range(self.task.FIRST_MAIN_Q, self.task.LAST_MAIN_Q + 1)
+
+        for qnum in qnums:
+            column_name = f"{self.task.FN_QPREFIX}{qnum}"
+
+            column_dict[column_name] = self.task.wxstring(req, column_name)
+
+        return self._get_response_percentages(
+            req,
+            column_dict=column_dict,
+            num_answers=3
+        )
+
+    def _get_ff_column_headings(self, req: "CamcopsRequest") -> List[str]:
+        _ = req.gettext
+        return [_("Question")] + self.task.get_ff_options(req)
+
+    def _get_ff_rows(self, req: "CamcopsRequest") -> List[str]:
+        """
+        Percentage of people who answered x for the friends/family question
+        """
+        return self._get_response_percentages(
+            req,
+            column_dict={
+                "ff_rating": self.task.wxstring(
+                    req,
+                    f"{self.task.FN_QPREFIX}_ff_rating"
+                )
+            },
+            num_answers=6
+        )
+
+    def _get_ff_why_rows(self, req: "CamcopsRequest") -> List[str]:
+        """
+        Reasons for giving a particular answer to the friends/family question
+        """
+
+        options = self.task.get_ff_options(req)
+
+        query = (
+            select([
+                column("ff_rating"),
+                column("ff_why")
+            ])
+            .select_from(self.task.__table__)
+            .where(
+                and_(
+                    column("ff_rating").isnot(None),
+                    column("ff_why").isnot(None)
+                )
+            )
+            .order_by("ff_why")
+        )
+
+        rows = []
+
+        for result in req.dbsession.execute(query).fetchall():
+            rows.append([options[result[0]], result[1]])
+
+        return rows
+
+    def _get_comments(self, req: "CamcopsRequest") -> List[str]:
+        """
+        A list of all the additional comments
+        """
+
+        query = (
+            select([
+                column("comments"),
+            ])
+            .select_from(self.task.__table__)
+            .where(
+                column("comments").isnot(None)
+            )
+        )
+
+        return req.dbsession.execute(query).fetchall()
+
+    def _get_response_percentages(self,
+                                  req: "CamcopsRequest",
+                                  column_dict: Dict[str, str],
+                                  num_answers: int) -> List[str]:
+
+        rows = []
+
+        for column_name, question in column_dict.items():
+            total_query = (
+                select([func.count(column_name)])
+                .select_from(self.task.__table__)
+                .where(column(column_name).isnot(None))
+            )
+
+            row = [question] + [0] * num_answers
+
+            query = (
+                select([
+                    column(column_name),
+                    100*(func.count(column_name)/total_query)
+                ])
+                .select_from(self.task.__table__)
+                .where(column(column_name).isnot(None))
+                .group_by(column_name)
+            )
+
+            for result in req.dbsession.execute(query):
+                row[result[0]+1] = result[1]
+
+            rows.append(row)
+
+        return rows

--- a/server/camcops_server/tasks/apeq_cpft_perinatal.py
+++ b/server/camcops_server/tasks/apeq_cpft_perinatal.py
@@ -313,7 +313,7 @@ class APEQCPFTPerinatalReport(Report):
                 .where(column(column_name).isnot(None))
             )
 
-            row = [question] + [0] * num_answers
+            row = [question] + [""] * num_answers
 
             """
             SELECT col, ((100 * COUNT(col)) / total_query)
@@ -331,7 +331,7 @@ class APEQCPFTPerinatalReport(Report):
             )
 
             for result in req.dbsession.execute(query):
-                row[result[0]+1] = result[1]
+                row[result[0]+1] = "{0:.1f}%".format(result[1])
 
             rows.append(row)
 
@@ -429,12 +429,12 @@ class APEQCPFTPerinatalReportTests(DemoDatabaseTestCase):
     def test_main_rows_contain_percentages(self):
         report = APEQCPFTPerinatalReport()
 
-        expected_q1 = [50, 25, 25]
-        expected_q2 = [0, 100, 0]
-        expected_q3 = [5, 20, 75]
-        expected_q4 = [10, 40, 50]
-        expected_q5 = [15, 55, 30]
-        expected_q6 = [0, 50, 50]
+        expected_q1 = ["50.0%", "25.0%", "25.0%"]
+        expected_q2 = ["", "100.0%", ""]
+        expected_q3 = ["5.0%", "20.0%", "75.0%"]
+        expected_q4 = ["10.0%", "40.0%", "50.0%"]
+        expected_q5 = ["15.0%", "55.0%", "30.0%"]
+        expected_q6 = ["", "50.0%", "50.0%"]
 
         main_rows = report._get_main_rows(self.req)
 
@@ -448,7 +448,8 @@ class APEQCPFTPerinatalReportTests(DemoDatabaseTestCase):
     def test_ff_rows_contain_percentages(self):
         report = APEQCPFTPerinatalReport()
 
-        expected_ff = [25, 10, 15, 10, 5, 35]
+        expected_ff = ["25.0%", "10.0%", "15.0%",
+                       "10.0%", "5.0%", "35.0%"]
 
         ff_rows = report._get_ff_rows(self.req)
 

--- a/server/camcops_server/tasks/apeq_cpft_perinatal.py
+++ b/server/camcops_server/tasks/apeq_cpft_perinatal.py
@@ -289,7 +289,12 @@ class APEQCPFTPerinatalReport(Report):
             )
         )
 
-        return req.dbsession.execute(query).fetchall()
+        comments = []
+
+        for result in req.dbsession.execute(query).fetchall():
+            comments.append(result[0])
+
+        return comments
 
     def _get_response_percentages(self,
                                   req: "CamcopsRequest",
@@ -471,7 +476,7 @@ class APEQCPFTPerinatalReportTests(DemoDatabaseTestCase):
         report = APEQCPFTPerinatalReport()
 
         expected_comments = [
-            ("comments_2",), ("comments_5",), ("comments_20",)
+            "comments_2", "comments_5", "comments_20",
         ]
 
         comments = report._get_comments(self.req)

--- a/server/camcops_server/tasks/apeq_cpft_perinatal.py
+++ b/server/camcops_server/tasks/apeq_cpft_perinatal.py
@@ -146,6 +146,14 @@ class APEQCPFTPerinatal(Task):
             </table>
         """
 
+    def get_main_options(self, req: "CamcopsRequest") -> List[str]:
+        options = []
+
+        for n in range(0, 2 + 1):
+            options.append(self.wxstring(req, f"main_a{n}"))
+
+        return options
+
     def get_ff_options(self, req: "CamcopsRequest") -> List[str]:
         options = []
 
@@ -200,10 +208,8 @@ class APEQCPFTPerinatalReport(Report):
 
     def _get_main_column_headings(self, req: "CamcopsRequest") -> List[str]:
         _ = req.gettext
-        names = [_("Question"), _("Total responses")]
-
-        for n in range(0, 2 + 1):
-            names.append(self.task.wxstring(req, f"main_a{n}"))
+        names = [_("Question"),
+                 _("Total responses")] + self.task.get_main_options(req)
 
         return names
 

--- a/server/camcops_server/templates/css/css_base.mako
+++ b/server/camcops_server/templates/css/css_base.mako
@@ -143,6 +143,19 @@ tr, th, td {
     line-height: ${va.TABLELINEHEIGHT};
 }
 
+blockquote > p {
+    background: #eee;
+    padding: 15px;
+}
+
+blockquote > p::before {
+    content: '\201C';
+}
+
+blockquote > p::after {
+    content: '\201D';
+}
+
 /* Specific classes */
 
 .badidpolicy_mild {
@@ -481,7 +494,7 @@ table.clinician, table.extradetail, table.general,
         font-size: ${va.SMALLFONTSIZE};
         line-height: ${va.SMALLLINEHEIGHT};
     }
-    
+
     /* PDF paging via CSS Paged Media */
     @page {
         size: A4 ${va.ORIENTATION};

--- a/server/camcops_server/templates/css/css_base.mako
+++ b/server/camcops_server/templates/css/css_base.mako
@@ -82,7 +82,7 @@ div {
     padding: ${va.NORMALPAD};
 }
 em {
-    color: rgb(0, 0, 255);
+    color: rgb(0, 0, 255);  /* blue */
     font-style: normal;
 }
 h1 {
@@ -144,25 +144,25 @@ tr, th, td {
 }
 
 blockquote > p {
-    background: #eee;
+    background: #eee;  /* light grey */
     padding: 15px;
 }
 
 blockquote > p::before {
-    content: '\201C';
+    content: '\201C';  /* left double quote */
 }
 
 blockquote > p::after {
-    content: '\201D';
+    content: '\201D';  /* right double quote */
 }
 
 /* Specific classes */
 
 .badidpolicy_mild {
-    background-color: rgb(255, 255, 153);  /* pale yellow */
+    background-color: rgb(255, 255, 153);  /* canary */
 }
 .badidpolicy_severe {
-    background-color: rgb(255, 255, 0);  /* bright yellow */
+    background-color: rgb(255, 255, 0);  /* yellow */
 }
 .invalid_id_number_foreground {
     color: rgb(128, 0, 128);  /* purple */

--- a/server/camcops_server/templates/snippets/table.mako
+++ b/server/camcops_server/templates/snippets/table.mako
@@ -25,8 +25,12 @@ camcops_server/templates/snippets/table.mako
 ===============================================================================
 
 </%doc>
-<%page args="column_headings, rows"/>
-<table>
+<%page args="column_headings, rows, table_class=None"/>
+<table
+%if table_class:
+class="${table_class}"
+%endif
+>
     <tr>
         %for c in column_headings:
             <th>${c | h}</th>
@@ -34,8 +38,8 @@ camcops_server/templates/snippets/table.mako
     </tr>
     %for row in rows:
         <tr>
-            %for val in row:
-                <td>
+            %for (col_index,val) in enumerate(row):
+                <td class="table-cell col-${col_index}">
                     ${val | h}
                 </td>
             %endfor

--- a/server/camcops_server/templates/snippets/table.mako
+++ b/server/camcops_server/templates/snippets/table.mako
@@ -1,7 +1,7 @@
 ## -*- coding: utf-8 -*-
 <%doc>
 
-camcops_server/templates/menu/report.mako
+camcops_server/templates/snippets/table.mako
 
 ===============================================================================
 
@@ -25,34 +25,20 @@ camcops_server/templates/menu/report.mako
 ===============================================================================
 
 </%doc>
-
-## <%page args="title: str, column_names: List[str], page: CamcopsPage"/>
-<%inherit file="base_web.mako"/>
-
-<%!
-from camcops_server.cc_modules.cc_pyramid import Routes, ViewArg, ViewParam
-%>
-
-<%include file="db_user_info.mako"/>
-
-<h1>${ title | h }</h1>
-
-<%block name="additional_report_above_results"></%block>
-
-<div>${page.pager()}</div>
-
-<%include file="table.mako" args="column_headings=column_names, rows=page"/>
-
-<div>${page.pager()}</div>
-
-<%block name="additional_report_below_results"></%block>
-
-<div>
-    <a href="${ request.route_url(Routes.OFFER_REPORT, _query={ViewParam.REPORT_ID: report_id}) }">${_("Re-configure report")}</a>
-</div>
-<div>
-    <a href="${request.route_url(Routes.REPORTS_MENU)}">${_("Return to reports menu")}</a>
-</div>
-<%include file="to_main_menu.mako"/>
-
-<%block name="additional_report_below_menu"></%block>
+<%page args="column_headings, rows"/>
+<table>
+    <tr>
+        %for c in column_headings:
+            <th>${c | h}</th>
+        %endfor
+    </tr>
+    %for row in rows:
+        <tr>
+            %for val in row:
+                <td>
+                    ${val | h}
+                </td>
+            %endfor
+        </tr>
+    %endfor
+</table>

--- a/server/camcops_server/templates/tasks/apeq_cpft_perinatal_report.mako
+++ b/server/camcops_server/templates/tasks/apeq_cpft_perinatal_report.mako
@@ -49,9 +49,12 @@ from camcops_server.cc_modules.cc_pyramid import Routes, ViewParam
 
 <%include file="table.mako" args="column_headings=[], rows=ff_why_rows"/>
 
-<h2>${_("Summary of comments")}</h2>
-<%include file="table.mako" args="column_headings=[], rows=comments"/>
-
+<h2>${_("Comments")}</h2>
+%for comment in comments:
+   <blockquote>
+       <p>${comment | h}</p>
+   </blockquote>
+%endfor
 <div>
     <a href="${ request.route_url(Routes.OFFER_REPORT, _query={ViewParam.REPORT_ID: report_id}) }">${_("Re-configure report")}</a>
 </div>

--- a/server/camcops_server/templates/tasks/apeq_cpft_perinatal_report.mako
+++ b/server/camcops_server/templates/tasks/apeq_cpft_perinatal_report.mako
@@ -27,6 +27,13 @@ camcops_server/templates/tasks/apeq_cpft_perinatal_report.mako
 </%doc>
 
 <%inherit file="base_web.mako"/>
+<%block name="css">
+${parent.css()}
+
+h2, h3 {
+    margin-top:20px;
+}
+</%block>
 
 <%!
 from camcops_server.cc_modules.cc_pyramid import Routes, ViewParam
@@ -41,7 +48,7 @@ from camcops_server.cc_modules.cc_pyramid import Routes, ViewParam
 
 <%include file="table.mako" args="column_headings=main_column_headings, rows=main_rows"/>
 
-<h2>${_("Friends/family questions")}</h2>
+<h2>${_("Friends / family questions")}</h2>
 
 <%include file="table.mako" args="column_headings=ff_column_headings, rows=ff_rows"/>
 

--- a/server/camcops_server/templates/tasks/apeq_cpft_perinatal_report.mako
+++ b/server/camcops_server/templates/tasks/apeq_cpft_perinatal_report.mako
@@ -1,0 +1,61 @@
+## -*- coding: utf-8 -*-
+<%doc>
+
+camcops_server/templates/tasks/apeq_cpft_perinatal_report.mako
+
+===============================================================================
+
+    Copyright (C) 2012-2019 Rudolf Cardinal (rudolf@pobox.com).
+
+    This file is part of CamCOPS.
+
+    CamCOPS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    CamCOPS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with CamCOPS. If not, see <http://www.gnu.org/licenses/>.
+
+===============================================================================
+
+</%doc>
+
+<%inherit file="base_web.mako"/>
+
+<%!
+from camcops_server.cc_modules.cc_pyramid import Routes, ViewParam
+%>
+
+
+<%include file="db_user_info.mako"/>
+
+<h1>${ title | h }</h1>
+
+<h2>${_("Main questions")}</h2>
+
+<%include file="table.mako" args="column_headings=main_column_headings, rows=main_rows"/>
+
+<h2>${_("Friends/family questions")}</h2>
+
+<%include file="table.mako" args="column_headings=ff_column_headings, rows=ff_rows"/>
+
+<h3>${_("Reasons given for the above responses")}</h3>
+
+<%include file="table.mako" args="column_headings=[], rows=ff_why_rows"/>
+
+<h2>${_("Summary of comments")}</h2>
+<%include file="table.mako" args="column_headings=[], rows=comments"/>
+
+<div>
+    <a href="${ request.route_url(Routes.OFFER_REPORT, _query={ViewParam.REPORT_ID: report_id}) }">${_("Re-configure report")}</a>
+</div>
+<div>
+    <a href="${request.route_url(Routes.REPORTS_MENU)}">${_("Return to reports menu")}</a>
+</div>
+<%include file="to_main_menu.mako"/>

--- a/server/camcops_server/templates/tasks/apeq_cpft_perinatal_report.mako
+++ b/server/camcops_server/templates/tasks/apeq_cpft_perinatal_report.mako
@@ -31,7 +31,19 @@ camcops_server/templates/tasks/apeq_cpft_perinatal_report.mako
 ${parent.css()}
 
 h2, h3 {
-    margin-top:20px;
+    margin-top: 20px;
+}
+
+.table-cell {
+    text-align: right;
+}
+
+.table-cell.col-0 {
+    text-align: initial;
+}
+
+.ff-why-table > tbody > tr > .col-1 {
+    text-align: initial;
 }
 </%block>
 
@@ -54,7 +66,7 @@ from camcops_server.cc_modules.cc_pyramid import Routes, ViewParam
 
 <h3>${_("Reasons given for the above responses")}</h3>
 
-<%include file="table.mako" args="column_headings=[], rows=ff_why_rows"/>
+<%include file="table.mako" args="column_headings=[], rows=ff_why_rows, table_class='ff-why-table'"/>
 
 <h2>${_("Comments")}</h2>
 %for comment in comments:


### PR DESCRIPTION
First iteration on APEQ CPFT Perinatal Report.

I'll put the date range filter in a separate PR.
TSV export is there as an option but gives the same as HTML. Once we've heard back from CPFT I'll either remove the option or implement a spreadsheet export as we discussed.

With the `DemoDatabaseTestCase` refactoring is there a way to type-hint the return values of the two `create_patient` methods without introducing circular imports?
