### PR TITLE
Initial performance improvements for Excel download

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ build-*/
 # Temporary
 *~
 *.tmp
+*.profile
 core
 
 # PyCharm
@@ -20,4 +21,3 @@ __pycache__/
 distributables/
 server/camcops_server.egg-info
 working/*
-

--- a/server/camcops_server/cc_modules/cc_debug.py
+++ b/server/camcops_server/cc_modules/cc_debug.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+
+"""
+camcops_server/cc_modules/cc_debug.py
+
+===============================================================================
+
+    Copyright (C) 2012-2019 Rudolf Cardinal (rudolf@pobox.com).
+
+    This file is part of CamCOPS.
+
+    CamCOPS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    CamCOPS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with CamCOPS. If not, see <http://www.gnu.org/licenses/>.
+
+===============================================================================
+
+**Debugging utilities**
+
+"""
+
+import cProfile
+
+
+# https://stackoverflow.com/questions/5375624/a-decorator-that-profiles-a-method-call-and-logs-the-profiling-result  # noqa
+def profile(func):
+    """
+    Decorator to generate profiler output for slow code
+    from camcops_server.cc_debug import profile.
+
+    Add @profile to the function you want to profile.
+    Will generate a file called <function name>.profile.
+
+    Can be visualised with e.g. SnakeViz (pip install snakeviz)
+    """
+
+    def wrapper(*args, **kwargs):
+        datafn = func.__name__ + ".profile"
+        prof = cProfile.Profile()
+        retval = prof.runcall(func, *args, **kwargs)
+        prof.dump_stats(datafn)
+
+        return retval
+
+    return wrapper

--- a/server/camcops_server/cc_modules/cc_tsv.py
+++ b/server/camcops_server/cc_modules/cc_tsv.py
@@ -285,11 +285,10 @@ class TsvCollection(object):
         """
         Returns the TSV collection as an XLSX (Excel) file.
         """
-        wb = XLWorkbook()
 
-        # we may have zero pages if there were no rows
-        if len(self.pages) > 0:
-            wb.remove(wb.active)  # remove the autocreated blank sheet
+        # Marginal performance gain with write_only. Does not automatically
+        # add a blank sheet
+        wb = XLWorkbook(write_only=True)
 
         for page in self.pages:
             ws = wb.create_sheet(title=page.name)

--- a/server/setup.py
+++ b/server/setup.py
@@ -96,6 +96,7 @@ INSTALL_REQUIRES = [
     # Alternative 'internal' web server. Installs fine under Windows, but won't run (ImportError: No module named 'fcntl').  # noqa
     'hl7==0.3.4',  # For HL7 export
     'lockfile==0.12.2',  # File locking for background tasks
+    'lxml==4.4.1',  # Will speed up openpyxl export
     'matplotlib==3.1.1',  # Used for trackers and some tasks. SLOW INSTALLATION.  # noqa
 
     # 'mysqlclient==1.3.13;platform_system=="Linux"',  # for mysql+mysqldb://...


### PR DESCRIPTION
* Use write-only for Excel export
* Add profile decorator
* Use lxml for improved openpyxl performance

I see that openpyxl is a requirement of cardinal_pythonlib rather than directly included here.

I cherry-picked a bug fix in cc_tsv.py from https://github.com/RudolfCardinal/camcops/pull/41 and then deleted the fixed code (write-only Worksheet doesn't automatically create a blank sheet). This leaves behind a test that doesn't really do much but I've kept it in, in the absence of any other tests.
 