### PR TITLE
Speed up patient relationships

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ build-*/
 # Temporary
 *~
 *.tmp
+*.profile
 core
 
 # PyCharm
@@ -20,4 +21,3 @@ __pycache__/
 distributables/
 server/camcops_server.egg-info
 working/*
-

--- a/server/camcops_server/cc_modules/cc_debug.py
+++ b/server/camcops_server/cc_modules/cc_debug.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+
+"""
+camcops_server/cc_modules/cc_debug.py
+
+===============================================================================
+
+    Copyright (C) 2012-2019 Rudolf Cardinal (rudolf@pobox.com).
+
+    This file is part of CamCOPS.
+
+    CamCOPS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    CamCOPS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with CamCOPS. If not, see <http://www.gnu.org/licenses/>.
+
+===============================================================================
+
+**Debugging utilities**
+
+"""
+
+import cProfile
+
+
+# https://stackoverflow.com/questions/5375624/a-decorator-that-profiles-a-method-call-and-logs-the-profiling-result  # noqa
+def profile(func):
+    """
+    Decorator to generate profiler output for slow code
+    from camcops_server.cc_debug import profile.
+
+    Add @profile to the function you want to profile.
+    Will generate a file called <function name>.profile.
+
+    Can be visualised with e.g. SnakeViz (pip install snakeviz)
+    """
+
+    def wrapper(*args, **kwargs):
+        datafn = func.__name__ + ".profile"
+        prof = cProfile.Profile()
+        retval = prof.runcall(func, *args, **kwargs)
+        prof.dump_stats(datafn)
+
+        return retval
+
+    return wrapper

--- a/server/camcops_server/cc_modules/cc_patient.py
+++ b/server/camcops_server/cc_modules/cc_patient.py
@@ -174,7 +174,14 @@ class Patient(GenericTabletRecordMixin, Base):
         ),
         uselist=True,
         viewonly=True,
-        # Not profiled - any benefit unclear # lazy="joined"
+        # Profiling results 2019-10-14 exporting 4185 phq9 records with
+        # unique patients to xlsx (task-patient relationship "selectin")
+        # lazy="select"  : 35.3s
+        # lazy="joined"  : 27.3s
+        # lazy="subquery": 15.2s (31.0s when task-patient also subquery)
+        # lazy="selectin": 26.4s
+        # See also patient relationship on Task class (cc_task.py)
+        lazy="subquery"
     )  # type: List[PatientIdNum]
 
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -803,11 +810,11 @@ def is_candidate_patient_valid(ptinfo: BarePatientInfo,
                                finalizing: bool) -> Tuple[bool, str]:
     """
     Is the specified patient acceptable to upload into this group?
-    
+
     Checks:
-    
+
     - group upload or finalize policy
-    
+
     .. todo:: is_candidate_patient_valid: check against predefined patients, if
        the group wants
 

--- a/server/camcops_server/cc_modules/cc_task.py
+++ b/server/camcops_server/cc_modules/cc_task.py
@@ -206,6 +206,7 @@ class TaskHasPatientMixin(object):
             ),
             uselist=False,
             viewonly=True,
+            lazy="joined"
             # EMPIRICALLY: SLOWER OVERALL WITH THIS # lazy="joined"
         )
         # NOTE: this retrieves the most recent (i.e. the current) information
@@ -1394,8 +1395,10 @@ class Task(GenericTabletRecordMixin, Base):
         Returns information used for the basic research dump in TSV format.
         """
         # 1. Our core fields, plus summary information
+
         main_page = self._get_core_tsv_page(req)
         # 2. Patient details.
+
         if self.patient:
             main_page.add_or_set_columns_from_page(
                 self.patient.get_tsv_page(req))

--- a/server/camcops_server/cc_modules/cc_task.py
+++ b/server/camcops_server/cc_modules/cc_task.py
@@ -206,8 +206,14 @@ class TaskHasPatientMixin(object):
             ),
             uselist=False,
             viewonly=True,
-            lazy="joined"
-            # EMPIRICALLY: SLOWER OVERALL WITH THIS # lazy="joined"
+            # Profiling results 2019-10-14 exporting 4185 phq9 records with
+            # unique patients to xlsx
+            # lazy="select"  : 59.7s
+            # lazy="joined"  : 44.3s
+            # lazy="subquery": 36.9s
+            # lazy="selectin": 35.3s
+            # See also idnums relationship on Patient class (cc_patient.py)
+            lazy="selectin"
         )
         # NOTE: this retrieves the most recent (i.e. the current) information
         # on that patient. Consequently, task version history doesn't show the

--- a/server/camcops_server/cc_modules/cc_tsv.py
+++ b/server/camcops_server/cc_modules/cc_tsv.py
@@ -285,11 +285,10 @@ class TsvCollection(object):
         """
         Returns the TSV collection as an XLSX (Excel) file.
         """
-        wb = XLWorkbook()
 
-        # we may have zero pages if there were no rows
-        if len(self.pages) > 0:
-            wb.remove(wb.active)  # remove the autocreated blank sheet
+        # Marginal performance gain with write_only. Does not automatically
+        # add a blank sheet
+        wb = XLWorkbook(write_only=True)
 
         for page in self.pages:
             ws = wb.create_sheet(title=page.name)

--- a/server/setup.py
+++ b/server/setup.py
@@ -96,6 +96,7 @@ INSTALL_REQUIRES = [
     # Alternative 'internal' web server. Installs fine under Windows, but won't run (ImportError: No module named 'fcntl').  # noqa
     'hl7==0.3.4',  # For HL7 export
     'lockfile==0.12.2',  # File locking for background tasks
+    'lxml==4.4.1',  # Will speed up openpyxl export
     'matplotlib==3.1.1',  # Used for trackers and some tasks. SLOW INSTALLATION.  # noqa
 
     # 'mysqlclient==1.3.13;platform_system=="Linux"',  # for mysql+mysqldb://...


### PR DESCRIPTION
Also includes optimisations from https://github.com/RudolfCardinal/camcops/pull/44 so review that one first, please

Once I had fixed my fake database to have valid eras on patient, task, and patient_idnum tables, there were performance gains for both task-patient and patient-idnums relationships. I've not exhaustively tested every combination of relationship but the combination of "subquery" and "selectin" seems to give the best result (time cut to a quarter for a single task table export).