### PR TITLE
Average score reports (MAAS, PBQ and CORE-10)

### DIFF
--- a/server/camcops_server/cc_modules/cc_report.py
+++ b/server/camcops_server/cc_modules/cc_report.py
@@ -45,12 +45,8 @@ from pyramid.renderers import render_to_response
 from pyramid.response import Response
 from sqlalchemy.engine.result import ResultProxy
 from sqlalchemy.orm.query import Query
-<<<<<<< HEAD
-from sqlalchemy.sql.expression import func, select, and_
-=======
 from sqlalchemy.sql.elements import ColumnElement
 from sqlalchemy.sql.expression import and_, column, func, select
->>>>>>> poem-report
 from sqlalchemy.sql.selectable import SelectBase
 
 # import as LITTLE AS POSSIBLE; this is used by lots of modules
@@ -75,12 +71,9 @@ if TYPE_CHECKING:
         ReportParamForm,
         ReportParamSchema,
     )
-<<<<<<< HEAD
     from camcops_server.cc_modules.cc_patient import Patient
     from camcops_server.cc_modules.cc_patientidnum import PatientIdNum
     from camcops_server.cc_modules.cc_request import CamcopsRequest
-=======
->>>>>>> poem-report
     from camcops_server.cc_modules.cc_task import Task
 
 log = BraceStyleAdapter(logging.getLogger(__name__))

--- a/server/camcops_server/cc_modules/cc_report.py
+++ b/server/camcops_server/cc_modules/cc_report.py
@@ -540,7 +540,7 @@ class ScoreDetails(object):
         self.max = max
 
 
-class AverageScoreReport(Report):
+class AverageScoreReport(DateTimeFilteredReportMixin, Report):
     """
     Used by MAAS, CORE-10 and PBQ to report average scores and progress
     """
@@ -584,6 +584,9 @@ class AverageScoreReport(Report):
         FROM core10 GROUP BY patient_id
         """
 
+        wheres = []
+        self.add_report_filters(wheres)
+
         first_latest_record_query = (
             select([self.task_class.patient_id,
                     func.min(self.task_class.when_created)
@@ -591,6 +594,7 @@ class AverageScoreReport(Report):
                     func.max(self.task_class.when_created)
                     .label("max_when_created")])
             .select_from(self.task_class.__table__)
+            .where(and_(*wheres))
             .group_by(self.task_class.patient_id)
         )
 

--- a/server/camcops_server/cc_modules/cc_report.py
+++ b/server/camcops_server/cc_modules/cc_report.py
@@ -226,7 +226,6 @@ class Report(object):
         reports. Used by :class:`DateTimeFilteredReportMixin`.
         """
 
-
     # -------------------------------------------------------------------------
     # Common functionality: classmethods
     # -------------------------------------------------------------------------
@@ -433,8 +432,8 @@ class PercentageSummaryReportMixin(object):
                                  req: "CamcopsRequest",
                                  column_dict: Dict[str, str],
                                  num_answers: int,
-                                 cell_format: str="{}",
-                                 min_answer: int=0) -> List[List[str]]:
+                                 cell_format: str = "{}",
+                                 min_answer: int = 0) -> List[List[str]]:
         """
         Provides a summary of each question, x% of people said each response.
         """
@@ -609,7 +608,7 @@ class AverageScoreReport(DateTimeFilteredReportMixin, Report):
             select([first_latest_records.c.patient_id,
                     first_latest_records.c.max_when_created])
             .select_from(first_latest_records)
-            .where(first_latest_records.c.min_when_created != first_latest_records.c.max_when_created)
+            .where(first_latest_records.c.min_when_created != first_latest_records.c.max_when_created)  # noqa: E501
         )
 
         latest_records = latest_record_query.alias(

--- a/server/camcops_server/cc_modules/cc_report.py
+++ b/server/camcops_server/cc_modules/cc_report.py
@@ -104,10 +104,11 @@ class Report(object):
     See the explanations of each.
     """
 
+    template_name = "report.mako"
+
     # -------------------------------------------------------------------------
     # Attributes that must be provided
     # -------------------------------------------------------------------------
-
     # noinspection PyMethodParameters
     @classproperty
     def report_id(cls) -> str:
@@ -321,7 +322,7 @@ class Report(object):
         If you wish, you can override this for more report customization.
         """
         return render_to_response(
-            "report.mako",
+            self.template_name,
             dict(title=self.title(req),
                  page=page,
                  column_names=column_names,

--- a/server/camcops_server/cc_modules/cc_report.py
+++ b/server/camcops_server/cc_modules/cc_report.py
@@ -335,6 +335,8 @@ class AverageScoreReport(Report):
     """
     Used by MAAS, CORE-10 and PBQ to report average scores and progress
     """
+    template_name = "average_score_report.mako"
+
     @classproperty
     def superuser_only(cls) -> bool:
         return False

--- a/server/camcops_server/cc_modules/cc_sqla_coltypes.py
+++ b/server/camcops_server/cc_modules/cc_sqla_coltypes.py
@@ -905,7 +905,7 @@ class PendulumDateTimeAsIsoTextColType(TypeDecorator):
             try:
                 processed_other = convert_datetime_to_utc(
                     coerce_to_pendulum(other))
-            except (AttributeError, ParserError, ValueError):
+            except (AttributeError, ParserError, TypeError, ValueError):
                 # OK. At this point, "other" could be a plain DATETIME field,
                 # or a PendulumDateTimeAsIsoTextColType field (or potentially
                 # something else that we don't really care about). If it's a

--- a/server/camcops_server/cc_modules/webview.py
+++ b/server/camcops_server/cc_modules/webview.py
@@ -2956,7 +2956,7 @@ class EraseTaskBaseView(object):
 
         if not hasattr(self, "template_name"):
             raise NotImplementedError(
-                f"{self.__class__.__name__} must defined template_name"
+                f"{self.__class__.__name__} must define template_name"
             )
 
     def dispatch(self) -> Response:

--- a/server/camcops_server/tasks/core10.py
+++ b/server/camcops_server/tasks/core10.py
@@ -388,48 +388,6 @@ class Core10EmptyReportTests(Core10ReportTestCase):
         )
 
 
-class Core10DuplicateEntryTests(Core10ReportTestCase):
-    def create_tasks(self):
-        self.patient_1 = self.create_patient()
-        self.patient_2 = self.create_patient()
-        self.patient_3 = self.create_patient()
-
-        # Initial average score = (8 + 6 + 4) / 3 = 6
-        # Latest average score = (2 + 3 + 4) / 3 = 3
-        self.create_task(patient=self.patient_1, q1=4, q2=4,
-                         era="2018-06-01")  # Score 8
-        self.create_task(patient=self.patient_1, q1=4, q2=4,
-                         era="2018-06-01")  # Score 8
-        self.create_task(patient=self.patient_1, q7=1, q8=1,
-                         era="2018-10-04")  # Score 2
-
-        self.create_task(patient=self.patient_2, q3=3, q4=3,
-                         era="2018-05-02")  # Score 6
-        self.create_task(patient=self.patient_2, q3=2, q4=1,
-                         era="2018-10-03")  # Score 3
-
-        self.create_task(patient=self.patient_3, q5=2, q6=2,
-                         era="2018-01-10")  # Score 4
-        self.create_task(patient=self.patient_3, q9=1, q10=3,
-                         era="2018-10-01")  # Score 4
-        self.dbsession.commit()
-
-    def test_record_with_matching_timestamp_ignored(self) -> None:
-        plain_report = self.report.get_rows_colnames(self.req)
-
-        expected_rows = [
-            [
-                3,  # Initial total
-                3,  # Latest total
-                6,  # Initial average
-                3,  # Latest average
-                3,  # Average progress
-            ]
-        ]
-
-        self.assertEqual(plain_report.rows, expected_rows)
-
-
 class Core10DoubleCountingTests(Core10ReportTestCase):
     def create_tasks(self):
         self.patient_1 = self.create_patient()
@@ -460,8 +418,8 @@ class Core10DoubleCountingTests(Core10ReportTestCase):
                 3,  # Initial total
                 2,  # Latest total
                 6,  # Initial average
-                2,  # Latest average
-                4,  # Average progress
+                3,  # Latest average
+                3,  # Average progress
             ]
         ]
 

--- a/server/camcops_server/tasks/core10.py
+++ b/server/camcops_server/tasks/core10.py
@@ -307,9 +307,9 @@ class Core10ReportTestCase(AverageScoreReportTestCase):
         return Core10Report()
 
     def create_task(self, patient: Patient,
-                    q1: int=0, q2: int=0, q3: int=0, q4: int=0,
-                    q5: int=0, q6: int=0, q7: int=0, q8: int=0,
-                    q9: int=0, q10: int=0, era: str=None) -> None:
+                    q1: int = 0, q2: int = 0, q3: int = 0, q4: int = 0,
+                    q5: int = 0, q6: int = 0, q7: int = 0, q8: int = 0,
+                    q9: int = 0, q10: int = 0, era: str = None) -> None:
         task = Core10()
         self.apply_standard_task_fields(task)
         task.id = next(self.task_id_sequence)

--- a/server/camcops_server/tasks/core10.py
+++ b/server/camcops_server/tasks/core10.py
@@ -364,8 +364,8 @@ class Core10ReportTests(Core10ReportTestCase):
         expected_rows = [
             [
                 3,  # Initial total
-                6,  # Initial average
                 3,  # Latest total
+                6,  # Initial average
                 3,  # Latest average
                 3,  # Average progress
             ]
@@ -382,7 +382,7 @@ class Core10EmptyReportTests(Core10ReportTestCase):
             plain_report.rows,
             [
                 [
-                    0, "No data", 0, "No data", "Unable to calculate",
+                    0, 0, "No data", "No data", "Unable to calculate",
                 ]
             ]
         )

--- a/server/camcops_server/tasks/core10.py
+++ b/server/camcops_server/tasks/core10.py
@@ -386,3 +386,83 @@ class Core10EmptyReportTests(Core10ReportTestCase):
                 ]
             ]
         )
+
+
+class Core10DuplicateEntryTests(Core10ReportTestCase):
+    def create_tasks(self):
+        self.patient_1 = self.create_patient()
+        self.patient_2 = self.create_patient()
+        self.patient_3 = self.create_patient()
+
+        # Initial average score = (8 + 6 + 4) / 3 = 6
+        # Latest average score = (2 + 3 + 4) / 3 = 3
+        self.create_task(patient=self.patient_1, q1=4, q2=4,
+                         era="2018-06-01")  # Score 8
+        self.create_task(patient=self.patient_1, q1=4, q2=4,
+                         era="2018-06-01")  # Score 8
+        self.create_task(patient=self.patient_1, q7=1, q8=1,
+                         era="2018-10-04")  # Score 2
+
+        self.create_task(patient=self.patient_2, q3=3, q4=3,
+                         era="2018-05-02")  # Score 6
+        self.create_task(patient=self.patient_2, q3=2, q4=1,
+                         era="2018-10-03")  # Score 3
+
+        self.create_task(patient=self.patient_3, q5=2, q6=2,
+                         era="2018-01-10")  # Score 4
+        self.create_task(patient=self.patient_3, q9=1, q10=3,
+                         era="2018-10-01")  # Score 4
+        self.dbsession.commit()
+
+    def test_record_with_matching_timestamp_ignored(self) -> None:
+        plain_report = self.report.get_rows_colnames(self.req)
+
+        expected_rows = [
+            [
+                3,  # Initial total
+                3,  # Latest total
+                6,  # Initial average
+                3,  # Latest average
+                3,  # Average progress
+            ]
+        ]
+
+        self.assertEqual(plain_report.rows, expected_rows)
+
+
+class Core10DoubleCountingTests(Core10ReportTestCase):
+    def create_tasks(self):
+        self.patient_1 = self.create_patient()
+        self.patient_2 = self.create_patient()
+        self.patient_3 = self.create_patient()
+
+        # Initial average score = (8 + 6 + 4) / 3 = 6
+        # Latest average score = (3 + 3) / 3 = 2
+        self.create_task(patient=self.patient_1, q1=4, q2=4,
+                         era="2018-06-01")  # Score 8
+
+        self.create_task(patient=self.patient_2, q3=3, q4=3,
+                         era="2018-05-02")  # Score 6
+        self.create_task(patient=self.patient_2, q3=2, q4=1,
+                         era="2018-10-03")  # Score 3
+
+        self.create_task(patient=self.patient_3, q5=2, q6=2,
+                         era="2018-01-10")  # Score 4
+        self.create_task(patient=self.patient_3, q9=1, q10=2,
+                         era="2018-10-01")  # Score 3
+        self.dbsession.commit()
+
+    def test_record_does_not_appear_in_first_and_latest(self) -> None:
+        plain_report = self.report.get_rows_colnames(self.req)
+
+        expected_rows = [
+            [
+                3,  # Initial total
+                2,  # Latest total
+                6,  # Initial average
+                2,  # Latest average
+                4,  # Average progress
+            ]
+        ]
+
+        self.assertEqual(plain_report.rows, expected_rows)

--- a/server/camcops_server/tasks/core10.py
+++ b/server/camcops_server/tasks/core10.py
@@ -26,7 +26,7 @@ camcops_server/tasks/core10.py
 
 """
 
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Type
 
 from cardinal_pythonlib.classes import classproperty
 from cardinal_pythonlib.stringfunc import strseq
@@ -272,6 +272,7 @@ class Core10Report(AverageScoreReport):
     An average score of the people seen at the start of treatment
     an average final measure and an average progress score.
     """
+    # noinspection PyMethodParameters
     @classproperty
     def report_id(cls) -> str:
         return "core10"
@@ -281,8 +282,9 @@ class Core10Report(AverageScoreReport):
         _ = req.gettext
         return _("CORE-10 — Average scores")
 
+    # noinspection PyMethodParameters
     @classproperty
-    def task_class(cls) -> Task:
+    def task_class(cls) -> Type[Task]:
         return Core10
 
     @classmethod
@@ -292,11 +294,12 @@ class Core10Report(AverageScoreReport):
             ScoreDetails(
                 name=_("CORE-10 clinical score"),
                 fieldnames=Core10.QUESTION_FIELDNAMES,
-                min=0,
-                max=Core10.MAX_SCORE
+                minimum=0,
+                maximum=Core10.MAX_SCORE
             )
         ]
 
+    # noinspection PyMethodParameters
     @classproperty
     def higher_score_is_better(cls) -> bool:
         return False

--- a/server/camcops_server/tasks/core10.py
+++ b/server/camcops_server/tasks/core10.py
@@ -41,6 +41,7 @@ from camcops_server.cc_modules.cc_patient import Patient
 from camcops_server.cc_modules.cc_report import (
     AverageScoreReport,
     AverageScoreReportTestCase,
+    ScoreDetails,
 )
 from camcops_server.cc_modules.cc_request import CamcopsRequest
 from camcops_server.cc_modules.cc_snomed import SnomedExpression, SnomedLookup
@@ -284,9 +285,17 @@ class Core10Report(AverageScoreReport):
     def task_class(cls) -> Task:
         return Core10
 
-    @classproperty
-    def total_score_fieldnames(cls) -> List[str]:
-        return Core10.QUESTION_FIELDNAMES
+    @classmethod
+    def scores(cls, req: "CamcopsRequest") -> List[ScoreDetails]:
+        _ = req.gettext
+        return [
+            ScoreDetails(
+                name=_("CORE-10 clinical score"),
+                fieldnames=Core10.QUESTION_FIELDNAMES,
+                min=0,
+                max=Core10.MAX_SCORE
+            )
+        ]
 
     @classproperty
     def higher_score_is_better(cls) -> bool:

--- a/server/camcops_server/tasks/maas.py
+++ b/server/camcops_server/tasks/maas.py
@@ -28,6 +28,7 @@ camcops_server/tasks/maas.py
 
 from typing import Any, Dict, List, Optional, Tuple, Type
 
+from cardinal_pythonlib.classes import classproperty
 from cardinal_pythonlib.stringfunc import strseq
 from sqlalchemy.ext.declarative import DeclarativeMeta
 from sqlalchemy.sql.sqltypes import Integer
@@ -35,6 +36,7 @@ from sqlalchemy.sql.sqltypes import Integer
 from camcops_server.cc_modules.cc_constants import CssClass
 from camcops_server.cc_modules.cc_db import add_multiple_columns
 from camcops_server.cc_modules.cc_html import tr_qa
+from camcops_server.cc_modules.cc_report import AverageScoreReport
 from camcops_server.cc_modules.cc_request import CamcopsRequest
 from camcops_server.cc_modules.cc_summaryelement import SummaryElement
 from camcops_server.cc_modules.cc_task import Task, TaskHasPatientMixin
@@ -235,7 +237,7 @@ class Maas(TaskHasPatientMixin, Task,
             global score is the sum of all questions.
           </div>
           <div class="{CssClass.FOOTNOTES}">
-            Condon, J. (2015). Maternal Antenatal Attachment Scale 
+            Condon, J. (2015). Maternal Antenatal Attachment Scale
             [Measurement instrument]. Retrieved from <a
             href="http://hdl.handle.net/2328/35292">http://hdl.handle.net/2328/35292</a>.
 
@@ -247,3 +249,14 @@ class Maas(TaskHasPatientMixin, Task,
             any medium, provided the original work is properly cited.
           </div>
         """
+
+
+class MaasReport(AverageScoreReport):
+    @classproperty
+    def report_id(cls) -> str:
+        return "MAAS"
+
+    @classmethod
+    def title(cls, req: "CamcopsRequest") -> str:
+        _ = req.gettext
+        return _("MAAS — Average scores")

--- a/server/camcops_server/tasks/maas.py
+++ b/server/camcops_server/tasks/maas.py
@@ -322,7 +322,7 @@ class MaasReportTests(AverageScoreReportTestCase):
                          era="2019-06-01")  # total 17 + 5 + 5
         self.dbsession.commit()
 
-    def create_task(self, patient: Patient, era: str=None, **kwargs):
+    def create_task(self, patient: Patient, era: str = None, **kwargs):
         task = Maas()
         self.apply_standard_task_fields(task)
         task.id = next(self.task_id_sequence)

--- a/server/camcops_server/tasks/maas.py
+++ b/server/camcops_server/tasks/maas.py
@@ -268,6 +268,7 @@ class Maas(TaskHasPatientMixin, Task,
 
 
 class MaasReport(AverageScoreReport):
+    # noinspection PyMethodParameters
     @classproperty
     def report_id(cls) -> str:
         return "MAAS"
@@ -277,8 +278,9 @@ class MaasReport(AverageScoreReport):
         _ = req.gettext
         return _("MAAS — Average scores")
 
+    # noinspection PyMethodParameters
     @classproperty
-    def task_class(cls) -> Task:
+    def task_class(cls) -> Type[Task]:
         return Maas
 
     @classmethod
@@ -288,23 +290,22 @@ class MaasReport(AverageScoreReport):
             ScoreDetails(
                 name=_("Global attachment score"),
                 fieldnames=Maas.TASK_FIELDS,
-                min=Maas.MIN_GLOBAL,
-                max=Maas.MAX_GLOBAL
+                minimum=Maas.MIN_GLOBAL,
+                maximum=Maas.MAX_GLOBAL
             ),
             ScoreDetails(
                 name=_("Quality of attachment score"),
                 fieldnames=Maas.QUALITY_OF_ATTACHMENT_FIELDS,
-                min=Maas.MIN_QUALITY,
-                max=Maas.MAX_QUALITY
+                minimum=Maas.MIN_QUALITY,
+                maximum=Maas.MAX_QUALITY
             ),
             ScoreDetails(
                 name=_("Time spent in attachment mode"),
                 fieldnames=Maas.TIME_IN_ATTACHMENT_FIELDS,
-                min=Maas.MIN_TIME,
-                max=Maas.MAX_TIME
+                minimum=Maas.MIN_TIME,
+                maximum=Maas.MAX_TIME
             )
         ]
-        return Maas.TASK_FIELDS
 
 
 class MaasReportTests(AverageScoreReportTestCase):

--- a/server/camcops_server/tasks/pbq.py
+++ b/server/camcops_server/tasks/pbq.py
@@ -302,6 +302,7 @@ class Pbq(TaskHasPatientMixin, Task,
 
 
 class PBQReport(AverageScoreReport):
+    # noinspection PyMethodParameters
     @classproperty
     def report_id(cls) -> str:
         return "PBQ"
@@ -311,8 +312,9 @@ class PBQReport(AverageScoreReport):
         _ = req.gettext
         return _("PBQ — Average scores")
 
+    # noinspection PyMethodParameters
     @classproperty
-    def task_class(cls) -> Task:
+    def task_class(cls) -> Type[Task]:
         return Pbq
 
     @classmethod
@@ -322,35 +324,36 @@ class PBQReport(AverageScoreReport):
             ScoreDetails(
                 name=_("Total score"),
                 fieldnames=Pbq.QUESTION_FIELDS,
-                min=0,
-                max=Pbq.MAX_TOTAL
+                minimum=0,
+                maximum=Pbq.MAX_TOTAL
             ),
             ScoreDetails(
                 name=_("Factor 1 score"),
                 fieldnames=Pbq.FACTOR_1_F,
-                min=0,
-                max=Pbq.FACTOR_1_MAX
+                minimum=0,
+                maximum=Pbq.FACTOR_1_MAX
             ),
             ScoreDetails(
                 name=_("Factor 2 score"),
                 fieldnames=Pbq.FACTOR_2_F,
-                min=0,
-                max=Pbq.FACTOR_2_MAX
+                minimum=0,
+                maximum=Pbq.FACTOR_2_MAX
             ),
             ScoreDetails(
                 name=_("Factor 3 score"),
                 fieldnames=Pbq.FACTOR_3_F,
-                min=0,
-                max=Pbq.FACTOR_3_MAX
+                minimum=0,
+                maximum=Pbq.FACTOR_3_MAX
             ),
             ScoreDetails(
                 name=_("Factor 4 score"),
                 fieldnames=Pbq.FACTOR_4_F,
-                min=0,
-                max=Pbq.FACTOR_4_MAX
+                minimum=0,
+                maximum=Pbq.FACTOR_4_MAX
             ),
         ]
 
+    # noinspection PyMethodParameters
     @classproperty
     def higher_score_is_better(cls) -> bool:
         return False

--- a/server/camcops_server/tasks/pbq.py
+++ b/server/camcops_server/tasks/pbq.py
@@ -28,6 +28,7 @@ camcops_server/tasks/pbq.py
 
 from typing import Any, Dict, List, Tuple, Type
 
+from cardinal_pythonlib.classes import classproperty
 from cardinal_pythonlib.stringfunc import strnumlist, strseq
 from sqlalchemy.ext.declarative import DeclarativeMeta
 from sqlalchemy.sql.sqltypes import Integer
@@ -35,6 +36,7 @@ from sqlalchemy.sql.sqltypes import Integer
 from camcops_server.cc_modules.cc_constants import CssClass
 from camcops_server.cc_modules.cc_ctvinfo import CTV_INCOMPLETE, CtvInfo
 from camcops_server.cc_modules.cc_html import answer, tr
+from camcops_server.cc_modules.cc_report import AverageScoreReport
 from camcops_server.cc_modules.cc_request import CamcopsRequest
 from camcops_server.cc_modules.cc_sqla_coltypes import (
     CamcopsColumn,
@@ -191,7 +193,7 @@ class Pbq(TaskHasPatientMixin, Task,
 
     def total_score(self) -> int:
         return self.sum_fields(self.QUESTION_FIELDS)
-    
+
     def factor_1_score(self) -> int:
         return self.sum_fields(self.FACTOR_1_F)
 
@@ -274,23 +276,46 @@ class Pbq(TaskHasPatientMixin, Task,
         h += f"""
             </table>
             <div class="{CssClass.FOOTNOTES}">
-                Factors and cut-off scores are from Brockington et al. (2006, 
+                Factors and cut-off scores are from Brockington et al. (2006,
                 PMID 16673041), as follows.
                 [1] General factor; ≤11 normal, ≥12 high; based on questions
                     {", ".join(str(x) for x in self.FACTOR_1_Q)}.
-                [2] Factor examining severe mother–infant relationship 
-                    disorders; ≤12 normal, ≥13 high (cf. original 2001 study 
+                [2] Factor examining severe mother–infant relationship
+                    disorders; ≤12 normal, ≥13 high (cf. original 2001 study
                     with ≤16 normal, ≥17 high); based on questions
                     {", ".join(str(x) for x in self.FACTOR_2_Q)}.
                 [3] Factor relating to infant-focused anxiety; ≤9 normal, ≥10
-                    high; based on questions 
+                    high; based on questions
                     {", ".join(str(x) for x in self.FACTOR_3_Q)}.
-                [4] Factor relating to thoughts of harm to infant; ≤1 normal, 
-                    ≥2 high (cf. original 2001 study with ≤2 normal, ≥3 high); 
-                    known low sensitivity; based on questions 
+                [4] Factor relating to thoughts of harm to infant; ≤1 normal,
+                    ≥2 high (cf. original 2001 study with ≤2 normal, ≥3 high);
+                    known low sensitivity; based on questions
                     {", ".join(str(x) for x in self.FACTOR_4_Q)}.
             </div>
-        """ 
+        """
         return h
 
     # No SNOMED codes for the PBQ (checked 2019-04-01).
+
+
+class PBQReport(AverageScoreReport):
+    @classproperty
+    def report_id(cls) -> str:
+        return "PBQ"
+
+    @classmethod
+    def title(cls, req: "CamcopsRequest") -> str:
+        _ = req.gettext
+        return _("PBQ — Average scores")
+
+    @classproperty
+    def task_class(cls) -> Task:
+        return Pbq
+
+    @classproperty
+    def total_score_fieldnames(cls) -> List[str]:
+        return Pbq.QUESTION_FIELDS
+
+    @classproperty
+    def higher_score_is_better(cls) -> bool:
+        return False

--- a/server/camcops_server/tasks/pbq.py
+++ b/server/camcops_server/tasks/pbq.py
@@ -36,7 +36,10 @@ from sqlalchemy.sql.sqltypes import Integer
 from camcops_server.cc_modules.cc_constants import CssClass
 from camcops_server.cc_modules.cc_ctvinfo import CTV_INCOMPLETE, CtvInfo
 from camcops_server.cc_modules.cc_html import answer, tr
-from camcops_server.cc_modules.cc_report import AverageScoreReport
+from camcops_server.cc_modules.cc_report import (
+    AverageScoreReport,
+    ScoreDetails,
+)
 from camcops_server.cc_modules.cc_request import CamcopsRequest
 from camcops_server.cc_modules.cc_sqla_coltypes import (
     CamcopsColumn,
@@ -312,9 +315,41 @@ class PBQReport(AverageScoreReport):
     def task_class(cls) -> Task:
         return Pbq
 
-    @classproperty
-    def total_score_fieldnames(cls) -> List[str]:
-        return Pbq.QUESTION_FIELDS
+    @classmethod
+    def scores(cls, req: "CamcopsRequest") -> List[ScoreDetails]:
+        _ = req.gettext
+        return [
+            ScoreDetails(
+                name=_("Total score"),
+                fieldnames=Pbq.QUESTION_FIELDS,
+                min=0,
+                max=Pbq.MAX_TOTAL
+            ),
+            ScoreDetails(
+                name=_("Factor 1 score"),
+                fieldnames=Pbq.FACTOR_1_F,
+                min=0,
+                max=Pbq.FACTOR_1_MAX
+            ),
+            ScoreDetails(
+                name=_("Factor 2 score"),
+                fieldnames=Pbq.FACTOR_2_F,
+                min=0,
+                max=Pbq.FACTOR_2_MAX
+            ),
+            ScoreDetails(
+                name=_("Factor 3 score"),
+                fieldnames=Pbq.FACTOR_3_F,
+                min=0,
+                max=Pbq.FACTOR_3_MAX
+            ),
+            ScoreDetails(
+                name=_("Factor 4 score"),
+                fieldnames=Pbq.FACTOR_4_F,
+                min=0,
+                max=Pbq.FACTOR_4_MAX
+            ),
+        ]
 
     @classproperty
     def higher_score_is_better(cls) -> bool:

--- a/server/camcops_server/templates/tasks/average_score_report.mako
+++ b/server/camcops_server/templates/tasks/average_score_report.mako
@@ -1,7 +1,7 @@
 ## -*- coding: utf-8 -*-
 <%doc>
 
-camcops_server/templates/menu/report.mako
+camcops_server/templates/tasks/average_score_report.mako
 
 ===============================================================================
 
@@ -26,39 +26,11 @@ camcops_server/templates/menu/report.mako
 
 </%doc>
 
-## <%page args="title: str, column_names: List[str], page: CamcopsPage"/>
-<%inherit file="base_web.mako"/>
-
-<%!
-from camcops_server.cc_modules.cc_pyramid import Routes, ViewArg, ViewParam
-%>
-
-<%include file="db_user_info.mako"/>
-
-<h1>${ title | h }</h1>
-
-<%block name="additional_report_above_results"></%block>
+<%inherit file="report.mako"/>
 
 <%block name="pager_above_results">
-<div>${page.pager()}</div>
 </%block>
 
-<%block name="table">
-<%include file="table.mako" args="column_headings=column_names, rows=page"/>
-</%block>
 
 <%block name="pager_below_results">
-<div>${page.pager()}</div>
 </%block>
-
-<%block name="additional_report_below_results"></%block>
-
-<div>
-    <a href="${ request.route_url(Routes.OFFER_REPORT, _query={ViewParam.REPORT_ID: report_id}) }">${_("Re-configure report")}</a>
-</div>
-<div>
-    <a href="${request.route_url(Routes.REPORTS_MENU)}">${_("Return to reports menu")}</a>
-</div>
-<%include file="to_main_menu.mako"/>
-
-<%block name="additional_report_below_menu"></%block>

--- a/server/camcops_server/templates/tasks/average_score_report.mako
+++ b/server/camcops_server/templates/tasks/average_score_report.mako
@@ -28,9 +28,15 @@ camcops_server/templates/tasks/average_score_report.mako
 
 <%inherit file="report.mako"/>
 
-<%block name="pager_above_results">
+<%block name="additional_report_above_results">
+    <div>
+        If date filters are applied, only tasks within the date range are
+        considered.
+    </div>
 </%block>
 
+<%block name="pager_above_results">
+</%block>
 
 <%block name="pager_below_results">
 </%block>


### PR DESCRIPTION
Follows on from https://github.com/RudolfCardinal/camcops/pull/47 so please review that one first)

Reports for MAAS, PBQ and CORE-10:
Average overall score of the people seen at the start of treatment, an average final measure and average progress. Also subscales for MAAS and PBQ.

Some scores are higher=better and others are lower=better. I've made the progress score always positive. Should it be?

The code assumes that no two tasks will have the same `when_created`. This may be the case following network failure when uploading but we do have the ability to delete tasks now.

A note about the change to `cc_sqla_coltypes.py`:
See https://docs.sqlalchemy.org/en/13/changelog/migration_06.html#an-important-expression-language-gotcha
If we do something like:
`Core10.when_created == latest_records.c.when_created` in a query we end up in
`coerce_to_pendulum()`, which has the line:
```
if not x:
    return None
```

The base `ClauseElement` now raises an exception if called in a boolean context:
`TypeError: Boolean value of this clause is not defined`

The easiest thing to do is to add `TypeError` to the list of exceptions already
handled in the `PendulumDateTimeAsIsoTextColType` class