### PR TITLE
Script to populate the database with random-ish patients and tasks

### DIFF
--- a/server/camcops_server/camcops_server.py
+++ b/server/camcops_server/camcops_server.py
@@ -186,6 +186,13 @@ def _downgrade_database_to_revision(
         confirm_downgrade_db=confirm_downgrade_db)
 
 
+def _add_dummy_data(cfg: "CamcopsConfig",
+                    confirm_add_dummy_data: bool = False) -> None:
+    from camcops_server.cc_modules.cc_dummy_database import add_dummy_data  # delayed import; import side effects  # noqa
+    add_dummy_data(cfg, confirm_add_dummy_data=confirm_add_dummy_data)
+    _reindex(cfg)
+
+
 def _create_database_from_scratch(cfg: "CamcopsConfig") -> None:
     # noinspection PyUnresolvedReferences
     import camcops_server.camcops_server_core  # delayed import; import side effects  # noqa
@@ -678,6 +685,24 @@ def camcops_main() -> int:
             revision=args.destination_db_revision,
             show_sql_only=args.show_sql_only,
             confirm_downgrade_db=args.confirm_downgrade_db,
+        )
+    )
+
+    # Developer: create dummy database
+    dummy_database_parser = add_sub(
+        subparsers, "dev_add_dummy_data", config_mandatory=True,
+        help="(DEVELOPER OPTION ONLY.) Populates the database with "
+        "a set of dummy patients and tasks for testing."
+    )
+
+    dummy_database_parser.add_argument(
+        '--confirm_add_dummy_data', action="store_true",
+        help="Must specify this too, as a safety measure")
+
+    dummy_database_parser.set_defaults(
+        func=lambda args: _add_dummy_data(
+            cfg=get_default_config_from_os_env(),
+            confirm_add_dummy_data=args.confirm_add_dummy_data,
         )
     )
 

--- a/server/camcops_server/camcops_server.py
+++ b/server/camcops_server/camcops_server.py
@@ -188,9 +188,8 @@ def _downgrade_database_to_revision(
 
 def _add_dummy_data(cfg: "CamcopsConfig",
                     confirm_add_dummy_data: bool = False) -> None:
-    from camcops_server.cc_modules.cc_dummy_database import add_dummy_data  # delayed import; import side effects  # noqa
-    add_dummy_data(cfg, confirm_add_dummy_data=confirm_add_dummy_data)
-    _reindex(cfg)
+    import camcops_server.camcops_server_core as core  # delayed import; import side effects  # noqa
+    core.add_dummy_data(cfg, confirm_add_dummy_data=confirm_add_dummy_data)
 
 
 def _create_database_from_scratch(cfg: "CamcopsConfig") -> None:

--- a/server/camcops_server/camcops_server_core.py
+++ b/server/camcops_server/camcops_server_core.py
@@ -739,6 +739,18 @@ def check_index(cfg: CamcopsConfig, show_all_bad: bool = False) -> bool:
     return ok
 
 
+def add_dummy_data(cfg: CamcopsConfig,
+                   confirm_add_dummy_data: bool = False) -> None:
+    if not confirm_add_dummy_data:
+        log.critical("Destructive action not confirmed! Refusing.")
+        return
+
+    from camcops_server.cc_modules.cc_dummy_database import DummyDataFactory
+    factory = DummyDataFactory(cfg)
+    factory.add_data()
+    reindex(cfg)
+
+
 # =============================================================================
 # Celery
 # =============================================================================

--- a/server/camcops_server/cc_modules/cc_dummy_database.py
+++ b/server/camcops_server/cc_modules/cc_dummy_database.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python
+
+"""
+camcops_server/cc_modules/cc_dummy_database.py
+
+===============================================================================
+
+    Copyright (C) 2012-2019 Rudolf Cardinal (rudolf@pobox.com).
+
+    This file is part of CamCOPS.
+
+    CamCOPS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    CamCOPS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with CamCOPS. If not, see <http://www.gnu.org/licenses/>.
+
+===============================================================================
+
+**Functions for dummy database creation for manual testing.**
+
+"""
+import logging
+import random
+from typing import TYPE_CHECKING
+
+from cardinal_pythonlib.datetimefunc import (
+    convert_datetime_to_utc,
+    format_datetime,
+)
+from cardinal_pythonlib.logs import BraceStyleAdapter
+from cardinal_pythonlib.nhs import generate_random_nhs_number
+import pendulum
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm.session import sessionmaker
+from sqlalchemy.sql.expression import func
+from sqlalchemy.sql.schema import Column
+from sqlalchemy.sql.sqltypes import Float, Integer
+
+from camcops_server.cc_modules.cc_constants import DateFormat
+from camcops_server.cc_modules.cc_device import Device
+from camcops_server.cc_modules.cc_group import Group
+from camcops_server.cc_modules.cc_idnumdef import IdNumDefinition
+from camcops_server.cc_modules.cc_patient import Patient
+from camcops_server.cc_modules.cc_patientidnum import PatientIdNum
+from camcops_server.cc_modules.cc_task import Task
+from camcops_server.cc_modules.cc_user import User
+
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session as SqlASession
+    from camcops_server.cc_modules.cc_config import CamcopsConfig
+    from camcops_server.cc_modules.cc_db import GenericTabletRecordMixin
+
+log = BraceStyleAdapter(logging.getLogger(__name__))
+
+
+def add_dummy_data(cfg: "CamcopsConfig",
+                   confirm_add_dummy_data: bool = False) -> None:
+    if not confirm_add_dummy_data:
+        log.critical("Destructive action not confirmed! Refusing.")
+        return
+
+    factory = DummyDataFactory(cfg)
+    factory.add_data()
+
+
+class DummyDataFactory(object):
+    FIRST_PATIENT_ID = 10001
+    NUM_PATIENTS = 5
+
+    DEFAULT_MIN_FLOAT = 0
+    DEFAULT_MAX_FLOAT = 1000
+
+    DEFAULT_MIN_INTEGER = 0
+    DEFAULT_MAX_INTEGER = 1000
+
+    def __init__(self, cfg: "CamcopsConfig"):
+        engine = cfg.get_sqla_engine()
+        self.dbsession = sessionmaker()(bind=engine)  # type: SqlASession
+
+    def add_data(self):
+        next_id = self.next_id(Group.id)
+
+        self.group = Group()
+        self.group.name = f"dummygroup {next_id}"
+        self.group.description = "Dummy group"
+        self.group.upload_policy = "sex AND anyidnum"
+        self.group.finalize_policy = "sex AND idnum1"
+        self.dbsession.add(self.group)
+        self.dbsession.commit()  # sets PK fields
+
+        self.user = User.get_system_user(self.dbsession)
+        self.user.upload_group_id = self.group.id
+
+        self.era_time = pendulum.now()
+        self.era_time_utc = convert_datetime_to_utc(self.era_time)
+        self.era = format_datetime(self.era_time, DateFormat.ISO8601)
+        self.server_device = Device.get_server_device(self.dbsession)
+
+        self.nhs_iddef = IdNumDefinition(which_idnum="1001",
+                                         description="NHS number (TEST)",
+                                         short_description="NHS#",
+                                         hl7_assigning_authority="NHS",
+                                         hl7_id_type="NHSN")
+        self.dbsession.add(self.nhs_iddef)
+        try:
+            self.dbsession.commit()
+        except IntegrityError:
+            self.dbsession.rollback()
+
+        for patient_id in range(self.FIRST_PATIENT_ID,
+                                self.FIRST_PATIENT_ID + self.NUM_PATIENTS):
+            self.add_patient(patient_id)
+            log.info(f"Adding tasks for patient {patient_id}")
+            self.add_tasks(patient_id)
+
+    def add_patient(self, patient_id: int) -> Patient:
+        log.info(f"Adding patient {patient_id}")
+
+        patient = Patient()
+
+        patient.id = patient_id
+        self.apply_standard_db_fields(patient)
+        patient.forename = f"Forename {patient_id}"
+        patient.surname = f"Surname {patient_id}"
+        patient.dob = pendulum.parse("1950-01-01")
+        self.dbsession.add(patient)
+
+        self.add_patient_idnum(patient_id)
+        self.dbsession.commit()
+
+        return patient
+
+    def add_patient_idnum(self, patient_id: int) -> PatientIdNum:
+        next_id = self.next_id(PatientIdNum.id)
+
+        patient_idnum = PatientIdNum()
+        patient_idnum.id = next_id
+        self.apply_standard_db_fields(patient_idnum)
+        patient_idnum.patient_id = patient_id
+        patient_idnum.which_idnum = self.nhs_iddef.which_idnum
+
+        # Always create the same NHS number for each patient
+        random.seed(patient_id)
+        patient_idnum.idnum_value = generate_random_nhs_number()
+        random.seed()
+
+        self.dbsession.add(patient_idnum)
+
+    def add_tasks(self, patient_id) -> Task:
+        for cls in Task.all_subclasses_by_tablename():
+            task = cls()
+            task.id = self.next_id(cls.id)
+            self.apply_standard_task_fields(task)
+            if task.has_patient:
+                task.patient_id = patient_id
+
+            self.fill_in_task_fields(task)
+
+            self.dbsession.add(task)
+            self.dbsession.commit()
+
+    def fill_in_task_fields(self, task: "Task"):
+        for column in task.__table__.columns:
+            if not self.column_is_q_field(column):
+                continue
+
+            if isinstance(column.type, Integer):
+                self.set_integer_field(task, column)
+                continue
+
+            if isinstance(column.type, Float):
+                self.set_float_field(task, column)
+
+    def set_integer_field(self, task: "Task", column: Column):
+        setattr(task, column.name, self.get_valid_integer_for_field(column))
+
+    def set_float_field(self, task: "Task", column: Column):
+        setattr(task, column.name, self.get_valid_float_for_field(column))
+
+    def get_valid_integer_for_field(self, column: Column):
+        min_value = self.DEFAULT_MIN_INTEGER
+        max_value = self.DEFAULT_MAX_INTEGER
+
+        value_checker = getattr(column, "permitted_value_checker", None)
+
+        if value_checker is not None:
+            if value_checker.permitted_values is not None:
+                return random.choice(value_checker.permitted_values)
+
+            if value_checker.minimum is not None:
+                min_value = value_checker.minimum
+
+            if value_checker.maximum is not None:
+                max_value = value_checker.maximum
+
+        return random.randint(min_value, max_value)
+
+    def get_valid_float_for_field(self, column: Column):
+        min_value = self.DEFAULT_MIN_FLOAT
+        max_value = self.DEFAULT_MAX_FLOAT
+
+        value_checker = getattr(column, "permitted_value_checker", None)
+
+        if value_checker is not None:
+            if value_checker.permitted_values is not None:
+                return random.choice(value_checker.permitted_values)
+
+            if value_checker.minimum is not None:
+                min_value = value_checker.minimum
+
+            if value_checker.maximum is not None:
+                max_value = value_checker.maximum
+
+        return random.uniform(min_value, max_value)
+
+    def column_is_q_field(self, column: Column):
+        if column.name.startswith("_"):
+            return False
+
+        if column.name in [
+            'editing_time_s',
+            'firstexit_is_abort',
+            'firstexit_is_finish',
+            'id',
+            'patient_id',
+            'when_created',
+            'when_firstexit',
+            'when_last_modified',
+        ]:
+            return False
+
+        return True
+
+    def next_id(self, column: Column):
+        max_id = self.dbsession.query(func.max(column)).scalar()
+        if max_id is None:
+            return 1
+
+        return max_id + 1
+
+    def apply_standard_task_fields(self, task: "Task") -> None:
+        """
+        Writes some default values to an SQLAlchemy ORM object representing
+        a task.
+        """
+        self.apply_standard_db_fields(task)
+        task.when_created = self.era_time
+
+    def apply_standard_db_fields(self,
+                                 obj: "GenericTabletRecordMixin") -> None:
+        """
+        Writes some default values to an SQLAlchemy ORM object representing a
+        record uploaded from a client (tablet) device.
+        """
+        obj._device_id = self.server_device.id
+        obj._era = self.era
+        obj._group_id = self.group.id
+        obj._current = True
+        obj._adding_user_id = self.user.id
+        obj._when_added_batch_utc = self.era_time_utc

--- a/server/camcops_server/cc_modules/cc_dummy_database.py
+++ b/server/camcops_server/cc_modules/cc_dummy_database.py
@@ -73,13 +73,13 @@ class DummyDataFactory(object):
     DEFAULT_MIN_INTEGER = 0
     DEFAULT_MAX_INTEGER = 1000
 
-    def __init__(self, cfg: "CamcopsConfig"):
+    def __init__(self, cfg: "CamcopsConfig") -> None:
         engine = cfg.get_sqla_engine()
         self.dbsession = sessionmaker()(bind=engine)  # type: SqlASession
 
         self.faker = Faker('en_GB')
 
-    def add_data(self):
+    def add_data(self) -> None:
         next_id = self.next_id(Group.id)
 
         self.group = Group()
@@ -98,7 +98,7 @@ class DummyDataFactory(object):
         self.era = format_datetime(self.era_time, DateFormat.ISO8601)
         self.server_device = Device.get_server_device(self.dbsession)
 
-        self.nhs_iddef = IdNumDefinition(which_idnum="1001",
+        self.nhs_iddef = IdNumDefinition(which_idnum=1001,
                                          description="NHS number (TEST)",
                                          short_description="NHS#",
                                          hl7_assigning_authority="NHS",
@@ -147,7 +147,7 @@ class DummyDataFactory(object):
 
         return patient
 
-    def add_patient_idnum(self, patient_id: int) -> PatientIdNum:
+    def add_patient_idnum(self, patient_id: int) -> None:
         next_id = self.next_id(PatientIdNum.id)
 
         patient_idnum = PatientIdNum()
@@ -164,7 +164,7 @@ class DummyDataFactory(object):
 
         self.dbsession.add(patient_idnum)
 
-    def add_tasks(self, patient_id) -> Task:
+    def add_tasks(self, patient_id: int):
         for cls in Task.all_subclasses_by_tablename():
             task = cls()
             task.id = self.next_id(cls.id)
@@ -177,7 +177,8 @@ class DummyDataFactory(object):
             self.dbsession.add(task)
             self.dbsession.commit()
 
-    def fill_in_task_fields(self, task: "Task"):
+    def fill_in_task_fields(self, task: Task) -> None:
+        # noinspection PyUnresolvedReferences
         for column in task.__table__.columns:
             if not self.column_is_q_field(column):
                 continue
@@ -201,22 +202,22 @@ class DummyDataFactory(object):
             if isinstance(column.type, UnicodeText):
                 self.set_unicode_text_field(task, column)
 
-    def set_integer_field(self, task: "Task", column: Column):
+    def set_integer_field(self, task: Task, column: Column) -> None:
         setattr(task, column.name, self.get_valid_integer_for_field(column))
 
-    def set_float_field(self, task: "Task", column: Column):
+    def set_float_field(self, task: Task, column: Column) -> None:
         setattr(task, column.name, self.get_valid_float_for_field(column))
 
-    def set_bool_field(self, task: "Task", column: Column):
+    def set_bool_field(self, task: Task, column: Column) -> None:
         setattr(task, column.name, self.faker.random.choice([False, True]))
 
-    def set_date_field(self, task: "Task", column: Column):
+    def set_date_field(self, task: Task, column: Column) -> None:
         setattr(task, column.name, self.faker.date_object())
 
-    def set_unicode_text_field(self, task: "Task", column: Column):
+    def set_unicode_text_field(self, task: Task, column: Column) -> None:
         setattr(task, column.name, self.faker.text())
 
-    def get_valid_integer_for_field(self, column: Column):
+    def get_valid_integer_for_field(self, column: Column) -> int:
         min_value = self.DEFAULT_MIN_INTEGER
         max_value = self.DEFAULT_MAX_INTEGER
 
@@ -234,7 +235,7 @@ class DummyDataFactory(object):
 
         return self.faker.random.randint(min_value, max_value)
 
-    def get_valid_float_for_field(self, column: Column):
+    def get_valid_float_for_field(self, column: Column) -> float:
         min_value = self.DEFAULT_MIN_FLOAT
         max_value = self.DEFAULT_MAX_FLOAT
 
@@ -252,7 +253,8 @@ class DummyDataFactory(object):
 
         return self.faker.random.uniform(min_value, max_value)
 
-    def column_is_q_field(self, column: Column):
+    @staticmethod
+    def column_is_q_field(column: Column) -> bool:
         if column.name.startswith("_"):
             return False
 
@@ -270,14 +272,14 @@ class DummyDataFactory(object):
 
         return True
 
-    def next_id(self, column: Column):
+    def next_id(self, column: Column) -> int:
         max_id = self.dbsession.query(func.max(column)).scalar()
         if max_id is None:
             return 1
 
         return max_id + 1
 
-    def apply_standard_task_fields(self, task: "Task") -> None:
+    def apply_standard_task_fields(self, task: Task) -> None:
         """
         Writes some default values to an SQLAlchemy ORM object representing
         a task.

--- a/server/setup.py
+++ b/server/setup.py
@@ -90,6 +90,7 @@ INSTALL_REQUIRES = [
     'distro==1.3.0',  # detecting Linux distribution
     'dogpile.cache==0.6.6',  # web caching
     # TO COME: 'fhirclient==3.2.0',  # For FHIR export
+    'faker==3.0.0',  # for dummy database creation
     'flake8>=3.7.8',  # for development;
     'flower==0.9.2',  # monitor for Celery
     'gunicorn==19.8.1',  # web server (Unix only)


### PR DESCRIPTION
This script will create five patients and one instance of every task per run. It will try to use valid values for integers and floats if limits have been set. Text fields are filled with nonsense. Uses faker for plausible names, dates of birth etc.

There's a bit of duplicate code from cc_unittest.py. At some point we might want to look at one of the test fixture libraries (eg factory_boy) for testing.

There's obvious scope for improvement though this has been good enough for testing REDCap.
