### PR TITLE
Fix default minimum value for QuLineEditDouble

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -2767,3 +2767,6 @@ Current C++/SQLite client, Python/SQLAlchemy server
 
 - :ref:`DAS28 <das28>` CRP and ESR changed from integer to floating point
   (Database revision 0045).
+
+- Bugfix to QuLineEditDouble, where the default minimum value was positive,
+  preventing zero or negative numbers from being entered.

--- a/tablet_qt/questionnairelib/qulineeditdouble.cpp
+++ b/tablet_qt/questionnairelib/qulineeditdouble.cpp
@@ -28,7 +28,16 @@
 QuLineEditDouble::QuLineEditDouble(FieldRefPtr fieldref,
                                    const bool allow_empty) :
     QuLineEdit(fieldref),
-    m_minimum(std::numeric_limits<double>::min()),
+    /* Compare
+       https://en.cppreference.com/w/cpp/types/numeric_limits/min
+       https://en.cppreference.com/w/cpp/types/numeric_limits/lowest
+       "For floating-point types with denormalization, min returns the minimum
+       positive normalized value. Note that this behavior may be unexpected,
+       especially when compared to the behavior of min for integral types.
+       To find the value that has no values less than it, use
+       numeric_limits::lowest."
+    */
+    m_minimum(std::numeric_limits<double>::lowest()),
     m_maximum(std::numeric_limits<double>::max()),
     m_decimals(2),
     m_allow_empty(allow_empty),

--- a/tablet_qt/questionnairelib/qulineeditdouble.h
+++ b/tablet_qt/questionnairelib/qulineeditdouble.h
@@ -47,7 +47,7 @@ protected:
     virtual void extraLineEditCreation(QLineEdit* editor) override;
 
 protected:
-    double m_minimum;  // minimum; may be std::numeric_limits<double>::min()
+    double m_minimum;  // minimum; may be std::numeric_limits<double>::lowest()
     double m_maximum;  // maximum; may be std::numeric_limits<double>::max()
     int m_decimals;  // maximum number of decimal places, for StrictDoubleValidator
     bool m_allow_empty;  // allow an empty field?


### PR DESCRIPTION
Use lowest(), not min() which turns out to be different