### PR TITLE
MOJO: Put some generous limits on alcohol units

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -2770,3 +2770,6 @@ Current C++/SQLite client, Python/SQLAlchemy server
 
 - Bugfix to QuLineEditDouble, where the default minimum value was positive,
   preventing zero or negative numbers from being entered.
+
+- Restrict alcohol units for :ref:`Khandaker GM — MOJO — Medical questionnaire
+  <khandaker_mojo_medical>`.

--- a/tablet_qt/tasks/khandakermojomedical.cpp
+++ b/tablet_qt/tasks/khandakermojomedical.cpp
@@ -340,10 +340,14 @@ OpenableWidget* KhandakerMojoMedical::editor(const bool read_only)
     };
 
     auto doubleQuestion = [this, &page](const QString &fieldname,
+                                        const double minimum,
+                                        const double maximum,
                                         const QString &hint) -> void {
         page->addElement(new QuText(xstring(Q_XML_PREFIX + fieldname)));
 
-        auto line_edit_double = new QuLineEditDouble(fieldRef(fieldname));
+        auto line_edit_double = new QuLineEditDouble(
+            fieldRef(fieldname), minimum, maximum
+        );
         line_edit_double->setHint(hint);
 
         page->addElement(line_edit_double);
@@ -412,7 +416,8 @@ OpenableWidget* KhandakerMojoMedical::editor(const bool read_only)
     yesNoQuestion(FN_HAD_INFECTION_TWO_MONTHS_PRECEDING);
     yesNoQuestion(FN_HAS_ALCOHOL_SUBSTANCE_DEPENDENCE);
     multiChoiceQuestion(FN_SMOKING_STATUS, N_SMOKING_STATUS_VALUES);
-    doubleQuestion(FN_ALCOHOL_UNITS_PER_WEEK, xstring("alcohol_units_hint"));
+    doubleQuestion(FN_ALCOHOL_UNITS_PER_WEEK, 0, 2000,
+                   xstring("alcohol_units_hint"));
 
     page->addElement(new QuText(xstring("medical_history_subtitle")));
     yesNoGrid(


### PR DESCRIPTION
Following 0f75aa3788b45212779c7951025d560c9fbf7c77 we should be allowed to enter zero in a QuLineEditDouble with no limits. This change adds some limits to the alcohol consumption question in the MOJO Medical Questionnaire (there is another bug which currently prevents negative numbers being entered for QuLineEditDouble, I'll look at that separately).