### PR TITLE
Fix labels and translations when deleting

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -2783,3 +2783,6 @@ Current C++/SQLite client, Python/SQLAlchemy server
 **Client and server v2.3.8, IN PROGRESS**
 
 - Fixed openpyxl conflict when installing from Debian package
+
+- Fixed blank labels on form to delete user and translation of "Danger" on
+  other deletion forms.

--- a/server/camcops_server/cc_modules/cc_forms.py
+++ b/server/camcops_server/cc_modules/cc_forms.py
@@ -317,6 +317,7 @@ class TranslatableValidateDangerousOperationNode(
     def after_bind(self, node: SchemaNode, kw: Dict[str, Any]) -> None:
         super().after_bind(node, kw)  # calls set_description()
         _ = self.gettext
+        node.title = _("Danger")
         user_entry = get_child_node(self, "user_entry")
         user_entry.title = _("Validate this dangerous operation")
 
@@ -2632,11 +2633,6 @@ class DeleteUserSchema(HardWorkConfirmationSchema):
     """
     user_id = HiddenIntegerNode()  # name must match ViewParam.USER_ID
     danger = TranslatableValidateDangerousOperationNode()
-
-    def after_bind(self, node: SchemaNode, kw: Dict[str, Any]) -> None:
-        _ = self.gettext
-        danger = get_child_node(self, "danger")
-        danger.title = _("Danger")
 
 
 class DeleteUserForm(DeleteCancelForm):


### PR DESCRIPTION
Fixes a bug where the checkbox labels on the form to delete a user were blank and the word "Danger" wasn't being translated on other forms (e.g. when deleting a patient).