### PR TITLE
MOJO Medical: Set "diagnosis date" / "time since" fields to mandatory

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -2804,3 +2804,7 @@ Current C++/SQLite client, Python/SQLAlchemy server
 
   Achieved via the generic function
   :meth:`camcops_server.cc_modules.cc_db.GenericTabletRecordMixin._gen_unique_lineage_objects`.
+
+- Bugfix to :ref:`Khandaker GM — MOJO — Medical questionnaire
+  <khandaker_mojo_medical>` where the diagnosis date / years since diagnosis fields were not
+  marked as mandatory.

--- a/tablet_qt/tasks/khandakermojomedical.cpp
+++ b/tablet_qt/tasks/khandakermojomedical.cpp
@@ -393,8 +393,8 @@ OpenableWidget* KhandakerMojoMedical::editor(const bool read_only)
     FieldRef::SetterFunction set_years = std::bind(
         &KhandakerMojoMedical::setDurationOfIllness, this, std::placeholders::_1);
 
-    m_fr_diagnosis_date = FieldRefPtr(new FieldRef(get_date, set_date, false));
-    m_fr_diagnosis_years = FieldRefPtr(new FieldRef(get_years, set_years, false));
+    m_fr_diagnosis_date = FieldRefPtr(new FieldRef(get_date, set_date, true));
+    m_fr_diagnosis_years = FieldRefPtr(new FieldRef(get_years, set_years, true));
 
     // We don't store duration of illness on the server
     page->addElement(new QuText(xstring("duration_of_illness")));


### PR DESCRIPTION
Although the user can enter either the diagnosis date or years since diagnosis, given that one field is automatically updated from the other, we can make both fields mandatory.

This means that the task won't get the green light until the user puts something in one or other of these fields.
