### PR TITLE
change_other_password bug fix

### DIFF
--- a/server/camcops_server/cc_modules/webview.py
+++ b/server/camcops_server/cc_modules/webview.py
@@ -776,8 +776,6 @@ def change_other_password(req: "CamcopsRequest") -> Response:
             # Change the password
             # -----------------------------------------------------------------
             user_id = appstruct.get(ViewParam.USER_ID)
-            if user_id == req.user_id:
-                return change_own_password(req)
             must_change_pw = appstruct.get(ViewParam.MUST_CHANGE_PASSWORD)
             new_password = appstruct.get(ViewParam.NEW_PASSWORD)
             user = User.get_user_by_id(req.dbsession, user_id)
@@ -795,7 +793,7 @@ def change_other_password(req: "CamcopsRequest") -> Response:
         if user_id is None:
             raise HTTPBadRequest(f"{_('Improper user_id of')} {user_id!r}")
         if user_id == req.user_id:
-            return change_own_password(req)
+            raise HTTPFound(req.route_url(Routes.CHANGE_OWN_PASSWORD))
         user = User.get_user_by_id(req.dbsession, user_id)
         if user is None:
             raise HTTPBadRequest(f"{_('Missing user for id')} {user_id}")


### PR DESCRIPTION
Fixed 'Missing user for id' error when changing own password through change_other_password. 

The GET request in change_other_password was calling the change_own_password function. This meant that because the page URL was unchanged, the POST request would still be on the change_other_password view. The hidden user_id html element is not required for the change_own_password function, so the user_id check failed. 

https://github.com/mtm93/camcops/blob/change_other_password_fix/server/camcops_server/cc_modules/webview.py#L781

The solution was to add a redirect instead of calling the change_own_password function.


