### PR TITLE
Wkhtmltox 0.12.6 1 ProtocolUnknownError fix

### DIFF
--- a/server/camcops_server/cc_modules/cc_constants.py
+++ b/server/camcops_server/cc_modules/cc_constants.py
@@ -197,6 +197,7 @@ WKHTMLTOPDF_OPTIONS = {  # dict for pdfkit
     "header-spacing": "3",  # mm, from content up to bottom of header
     "footer-spacing": "3",  # mm, from content down to top of footer
     "quiet": "",  # Suppress "Loading pages (1/6)" etc.
+    "enable-local-file-access": "",
 }
 
 

--- a/server/camcops_server/cc_modules/webview.py
+++ b/server/camcops_server/cc_modules/webview.py
@@ -776,8 +776,6 @@ def change_other_password(req: "CamcopsRequest") -> Response:
             # Change the password
             # -----------------------------------------------------------------
             user_id = appstruct.get(ViewParam.USER_ID)
-            if user_id == req.user_id:
-                return change_own_password(req)
             must_change_pw = appstruct.get(ViewParam.MUST_CHANGE_PASSWORD)
             new_password = appstruct.get(ViewParam.NEW_PASSWORD)
             user = User.get_user_by_id(req.dbsession, user_id)
@@ -795,7 +793,7 @@ def change_other_password(req: "CamcopsRequest") -> Response:
         if user_id is None:
             raise HTTPBadRequest(f"{_('Improper user_id of')} {user_id!r}")
         if user_id == req.user_id:
-            return change_own_password(req)
+            raise HTTPFound(req.route_url(Routes.CHANGE_OWN_PASSWORD))
         user = User.get_user_by_id(req.dbsession, user_id)
         if user is None:
             raise HTTPBadRequest(f"{_('Missing user for id')} {user_id}")


### PR DESCRIPTION
On updating to wkhtmltox 0.12.6-1 from 0.12.5-1, PDF generation failed with 'ProtocolUnknownError' (https://github.com/RudolfCardinal/camcops/issues/87).

Addition of the option "enable-local-file-access":"" to the WKHTMLTOPDF_OPTIONS dict in cc_constants.py fixes the issue and allows PDF generation.