### PR TITLE
updating wkhtmltopdf in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,8 @@ jobs:
       before_script:
         # Install wkhtmltopdf on headless ubuntu 18 vps
         # https://gist.github.com/lobermann/ca0e7bb2558b3b08923c6ae2c37a26ce
-        - wget https://downloads.wkhtmltopdf.org/0.12/0.12.5/wkhtmltox_0.12.5-1.bionic_amd64.deb
+        - wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.bionic_amd64.deb
         - sudo apt-get -y install fontconfig libxrender1 xfonts-75dpi xfonts-base
-        - sudo dpkg -i wkhtmltox_0.12.5-1.bionic_amd64.deb
+        - sudo dpkg -i wkhtmltox_0.12.6-1.bionic_amd64.deb
 
       script: travis_scripts/pip_install_and_tests


### PR DESCRIPTION
Travis had failed on step 'installing pip packages and running tests' executing the command: 'https://downloads.wkhtmltopdf.org/0.12/0.12.5/wkhtmltox_0.12.5-1.bionic_amd64.deb'. The location for wkhtmltox (0.12.5 & 0.12.6) has changed from wkhtmltopdf.org to github, which is believed to have caused the error.

This commit updates the download url and dpkg command for release 0.12.6-1 on the wkhtmltopdf github page.