### PR TITLE
Ignore no-deprecated-copy warnings on later clang on iOS

### DIFF
--- a/tablet_qt/camcops.pro
+++ b/tablet_qt/camcops.pro
@@ -153,6 +153,15 @@ if (gcc | clang):!ios:!android:!macx {
     QMAKE_CXXFLAGS += -Wno-deprecated-copy
 }
 
+# Later versions of clang on iOS *do* support (no-)deprecated-copy but the order
+# of warning flags seems to be important and removing !ios above doesn't work
+# QMAKE_CXXFLAGS_WARN_ON defaults to -Wall -W and our overrides need to come
+# after that
+ios {
+    QMAKE_CFLAGS_WARN_ON += -Wno-deprecated-copy
+    QMAKE_CXXFLAGS_WARN_ON += -Wno-deprecated-copy
+}
+
 # In release mode, optimize heavily:
 gcc {
     QMAKE_CXXFLAGS_RELEASE -= -O


### PR DESCRIPTION
Having gone through another cycle of iOS, macOS and Xcode updates, the new build environment now emits deprecated implicit copy constructor warnings and recognises no-deprecated-copy but for some reason we can't just add the warning to the QMAKE_CXX_FLAGS as we do on other platforms.

It only seems to work by appending to QMAKE_CXXFLAGS_WARN_ON (which defaults to all warnings + all extra warnings)
