### PR TITLE
Ensure unescaped template values are strings

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -3473,3 +3473,6 @@ Current C++/SQLite client, Python/SQLAlchemy server
 
 - Any user with the right privilege (not just the group administrator) can
   add/edit/delete and send emails to patients created on the server. The menu option **Manage scheduled tasks for patients** is now **Manage patients and their tasks**. (Database revision 0069)
+
+- Fix internal server error when viewing HTML APEQ CPFT Perinatal Report.
+  https://github.com/RudolfCardinal/camcops/issues/203

--- a/server/camcops_server/templates/snippets/displayfunc.mako
+++ b/server/camcops_server/templates/snippets/displayfunc.mako
@@ -38,7 +38,7 @@ camcops_server/templates/snippets/displayfunc.mako
         %if escape:
             ${ x }
         %else:
-            ${ x | n }
+            ${ x | n, str }
         %endif
     %endfor
 </%def>

--- a/server/camcops_server/templates/snippets/table.mako
+++ b/server/camcops_server/templates/snippets/table.mako
@@ -39,11 +39,11 @@ class="${ table_class | n }"
     %for row in rows:
         <tr>
             %for (col_index,val) in enumerate(row):
-                <td class="table-cell col-${col_index | n }">
+                <td class="table-cell col-${col_index | n,str }">
                     %if escape_cells:
                         ${ val }
                     %else:
-                        ${ val | n }
+                        ${ val | n,str }
                     %endif
                 </td>
             %endfor

--- a/server/camcops_server/templates/test/test_template_filters.mako
+++ b/server/camcops_server/templates/test/test_template_filters.mako
@@ -29,7 +29,7 @@ camcops_server/templates/test/test_template_filters.mako
 <%inherit file="base_web.mako"/>
 
 <div>
-    Testing Mako filtering:<br>
+    <h1>Testing Mako filtering:</h1>
 
     <table>
         <tr>
@@ -47,4 +47,15 @@ camcops_server/templates/test/test_template_filters.mako
             </tr>
         %endfor
     </table>
+
+    <%namespace file="displayfunc.mako" import="one_per_line"/>
+
+    <h2>one_per_line(), escaped</h2>
+    <p>
+        ${ one_per_line(["<span>Apple</span>", "Banana", "Carrot", 3.14159265359], escape=True ) | n}
+    </p>
+    <h2>one_per_line(), not escaped</h2>
+    <p>
+        ${ one_per_line(["<span>Apple</span>", "Banana", "Carrot", 3.14159265359], escape=False ) | n}
+    </p>
 </div>


### PR DESCRIPTION
Fixes #203 Internal Server Error when viewing the HTML APEQ CPFT Perinatal Report

As well as the reports.mako snippet, there's a potential problem with the `one_per_line()` formatter, though not with current usage.