### PR TITLE
Fixes to the build_qt.py script on various platforms

### DIFF
--- a/.github/workflows/build-qt.yml
+++ b/.github/workflows/build-qt.yml
@@ -27,6 +27,7 @@ jobs:
                   python -m pip freeze
                   echo installing pip packages
                   pip install cardinal_pythonlib
+                  pip install distro
             - name: Build Qt
               run: |
                   source ${HOME}/venv/bin/activate

--- a/.github/workflows/build-qt.yml
+++ b/.github/workflows/build-qt.yml
@@ -15,6 +15,12 @@ jobs:
             - uses: actions/setup-python@v2
               with:
                   python-version: 3.8
+            - name: Qt prerequisites
+              run: |
+                  set -xe
+                  sudo apt-get -y build-dep qt5-default
+                  sudo apt-get -y install libxcb-xinerama0-dev
+                  sudo apt-get -y install libdrm-dev libxcb-glx0-dev
             - name: Pip install
               run: |
                   set -xe

--- a/.github/workflows/build-qt.yml
+++ b/.github/workflows/build-qt.yml
@@ -17,12 +17,18 @@ jobs:
                   python-version: 3.8
             - name: Qt prerequisites
               run: |
+                  # https://wiki.qt.io/Building_Qt_5_from_Git
                   set -xe
                   codename=`lsb_release -cs`
                   echo "deb-src http://archive.ubuntu.com/ubuntu ${codename} universe" | sudo tee -a /etc/apt/sources.list
                   echo "deb-src http://archive.ubuntu.com/ubuntu ${codename}-updates universe" | sudo tee -a /etc/apt/sources.list
                   sudo apt-get update
                   sudo apt-get -y build-dep qt5-default
+                  sudo apt-get -y install build-essential perl python git
+                  sudo apt-get -y install '^libxcb.*-dev' libx11-xcb-dev libglu1-mesa-dev libxrender-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev
+                  sudo apt-get -y install flex bison gperf libicu-dev libxslt-dev ruby
+                  sudo apt-get -y install libxcursor-dev libxcomposite-dev libxdamage-dev libxrandr-dev libxtst-dev libxss-dev libdbus-1-dev libevent-dev libfontconfig1-dev libcap-dev libpulse-dev libudev-dev libpci-dev libnss3-dev libasound2-dev libegl1-mesa-dev gperf bison nodejs
+                  sudo apt-get -y install libasound2-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstreamer-plugins-good1.0-dev libgstreamer-plugins-bad1.0-dev
                   sudo apt-get -y install libxcb-xinerama0-dev
                   sudo apt-get -y install libdrm-dev libxcb-glx0-dev
             - name: Pip install

--- a/.github/workflows/build-qt.yml
+++ b/.github/workflows/build-qt.yml
@@ -6,6 +6,7 @@ on:
     push:
         paths:
             - tablet_qt/tools/build_qt.py
+            - .github/workflows/build-qt.yml
 jobs:
     build-qt:
         runs-on: ubuntu-latest
@@ -28,6 +29,7 @@ jobs:
                   pip install cardinal_pythonlib
             - name: Build Qt
               run: |
+                  source ${HOME}/venv/bin/activate
                   export CAMCOPS_QT_BASE_DIR=${HOME}/qt_local_build
                   cd tablet_qt/tools
                   ./build_qt.py --build_linux_x86_64

--- a/.github/workflows/build-qt.yml
+++ b/.github/workflows/build-qt.yml
@@ -1,0 +1,33 @@
+---
+# yamllint disable rule:line-length
+name: Build Qt
+# yamllint disable-line rule:truthy
+on:
+    push:
+        paths:
+            - tablet_qt/tools/build_qt.py
+jobs:
+    build-qt:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - uses: actions/setup-python@v2
+              with:
+                  python-version: 3.8
+            - name: Pip install
+              run: |
+                  set -xe
+                  python -m venv ${HOME}/venv
+                  source ${HOME}/venv/bin/activate
+                  python -VV
+                  python -m site
+                  python -m pip install -U pip
+                  echo dumping pre-installed packages
+                  python -m pip freeze
+                  echo installing pip packages
+                  pip install cardinal_pythonlib
+            - name: Build Qt
+              run: |
+                  export CAMCOPS_QT_BASE_DIR=${HOME}/qt_local_build
+                  cd tablet_qt/tools
+                  ./build_qt.py --build_linux_x86_64

--- a/.github/workflows/build-qt.yml
+++ b/.github/workflows/build-qt.yml
@@ -18,6 +18,10 @@ jobs:
             - name: Qt prerequisites
               run: |
                   set -xe
+                  codename=`lsb_release -cs`
+                  echo "deb-src http://archive.ubuntu.com/ubuntu ${codename} universe" | sudo tee -a /etc/apt/sources.list
+                  echo "deb-src http://archive.ubuntu.com/ubuntu ${codename}-updates universe" | sudo tee -a /etc/apt/sources.list
+                  sudo apt-get update
                   sudo apt-get -y build-dep qt5-default
                   sudo apt-get -y install libxcb-xinerama0-dev
                   sudo apt-get -y install libdrm-dev libxcb-glx0-dev

--- a/.github/workflows/push-to-repository.yml
+++ b/.github/workflows/push-to-repository.yml
@@ -2,7 +2,10 @@
 # yamllint disable rule:line-length
 name: Build
 # yamllint disable-line rule:truthy
-on: [push]
+on:
+    push:
+        paths:
+            - 'server/*'
 jobs:
     pip-install-and-tests:
         runs-on: ubuntu-latest

--- a/server/setup.py
+++ b/server/setup.py
@@ -157,7 +157,7 @@ INSTALL_REQUIRES = [
     'pyparsing==2.4.7',
     'PyPDF2==1.26.0',  # Used by cardinal_pythonlib.pdf
     'python-dateutil==2.8.1',  # date/time extensions.
-    'sqlparse==0.3.1',
+    'sqlparse==0.4.2',
 
     # extra
     'py-bcrypt==0.4',  # used by cardinal_pythonlib.crypto

--- a/tablet_qt/tools/build_qt.py
+++ b/tablet_qt/tools/build_qt.py
@@ -1408,7 +1408,7 @@ class Platform(object):
             else:
                 make = which_with_envpath(NMAKE, env)
                 supports_parallel = False
-            makefile_switch = "/F"
+            makefile_switch = "/FS"
             parallel_switch = "/J"
         else:
             make = MAKE
@@ -2750,7 +2750,7 @@ NOTE: If in doubt, on Unix-ish systems use './config'.
                 #     so we rely on the fact that cl.exe will interpret "-FS"
                 #     and "/FS" identically.
             elif target_platform.cpu_x86_32bit_family:
-                return ["VC-WIN32"]
+                return ["VC-WIN32", "-FS"]
 
     raise NotImplementedError(
         f"Don't known OpenSSL target name for {target_platform}")

--- a/tablet_qt/tools/build_qt.py
+++ b/tablet_qt/tools/build_qt.py
@@ -524,7 +524,7 @@ DEFAULT_QT_USE_OPENSSL_STATICALLY = True
 QT_XCB_SUPPORT_OK = True  # see 2017-12-01 above, fixed 2017-12-08
 ADD_SO_VERSION_OF_LIBQTFORANDROID = False
 USE_CLANG_NOT_GCC_FOR_ANDROID_ARM = (
-    QT_VERSION >= Version("5.12", partial=True)  # new feature 2019-06-15
+    QT_VERSION >= Version("5.12.0")  # new feature 2019-06-15
 )
 
 # OpenSSL

--- a/tablet_qt/tools/build_qt.py
+++ b/tablet_qt/tools/build_qt.py
@@ -3612,6 +3612,7 @@ def build_sqlcipher(cfg: Config, target_platform: Platform) -> None:
             # Try this:
             ldflags.append(static_openssl_lib)
             # ... https://github.com/sqlcipher/sqlcipher
+            cflags.append("-DSQLCIPHER_CRYPTO_OPENSSL")
         else:
             log.info("Linking OpenSSL into SQLCipher DYNAMICALLY")
             # make the executable load OpenSSL dynamically
@@ -3638,6 +3639,11 @@ def build_sqlcipher(cfg: Config, target_platform: Platform) -> None:
             f'CFLAGS={" ".join(cflags + gccflags)}',
             f'LDFLAGS={" ".join(ldflags)}',
         ]
+        if link_openssl_statically:
+            config_args.append("--with-crypto-lib=none")
+            config_args.append("--disable-shared")
+            config_args.append("--enable-static=yes")
+
         # By default, SQLCipher compiles with "-O2" optimizations under gcc;
         # see its "configure" script.
 

--- a/tablet_qt/tools/build_qt.py
+++ b/tablet_qt/tools/build_qt.py
@@ -1317,6 +1317,21 @@ class Platform(object):
         else:
             raise ValueError("Unknown combination for ios_platform_name")
 
+    @property
+    def macos_platform_name(self) -> str:
+        """
+        Needs to match MacOS SDK naming. Don't alter.
+        """
+        if not self.macos:
+            raise ValueError(
+                "macos_platform_name requested but not using MacOS"
+            )
+
+        if self.cpu_x86_family:
+            return "MacOSX"
+
+        raise ValueError("Unknown combination for macos_platform_name")
+
     # -------------------------------------------------------------------------
     # Other cross-compilation details
     # -------------------------------------------------------------------------
@@ -1769,15 +1784,25 @@ class Config(object):
         """
         if target_platform.android:
             return self._android_sysroot(target_platform)
-        elif target_platform.ios:
+
+        if target_platform.ios:
             return self._xcode_sdk_path(
                 xcode_platform=target_platform.ios_platform_name,
                 sdk_version=self._get_ios_sdk_version(
                     target_platform=target_platform))
-        elif target_platform.linux or target_platform.macos:
+
+        if target_platform.macos:
+            return self._xcode_sdk_path(
+                xcode_platform=target_platform.macos_platform_name,
+                sdk_version=""
+            )
+
+        if target_platform.linux:
             return "/"  # default sysroot
-        elif target_platform.windows:
+
+        if target_platform.windows:
             return env["WindowsSdkDir"]
+
         raise NotImplementedError(
             f"Don't know sysroot for target: {target_platform}")
 

--- a/tablet_qt/tools/build_qt.py
+++ b/tablet_qt/tools/build_qt.py
@@ -1394,7 +1394,8 @@ class Platform(object):
 
     def make_args(self, cfg: "Config", extra_args: List[str] = None,
                   command: str = "", makefile: str = "",
-                  env: Dict[str, str] = None) -> List[str]:
+                  env: Dict[str, str] = None,
+                  allow_parallel: bool = True) -> List[str]:
         """
         Generates command arguments for "make" or a platform equivalent.
         """
@@ -1417,7 +1418,7 @@ class Platform(object):
         # require(make)
         # ... not necessarily visible now; may be on a PATH yet to be set
         args = [make]
-        if supports_parallel:
+        if allow_parallel and supports_parallel:
             args += [parallel_switch, str(cfg.nparallel)]
         if extra_args:
             args += extra_args
@@ -1687,7 +1688,8 @@ class Config(object):
     # -------------------------------------------------------------------------
 
     def make_args(self, extra_args: List[str] = None, command: str = "",
-                  makefile: str = "", env: Dict[str, str] = None) -> List[str]:
+                  makefile: str = "", env: Dict[str, str] = None,
+                  allow_parallel: bool = True) -> List[str]:
         """
         Returns command arguments for "make" or a platform equivalent.
         """
@@ -1695,7 +1697,8 @@ class Config(object):
                                         extra_args=extra_args,
                                         command=command,
                                         makefile=makefile,
-                                        env=env)
+                                        env=env,
+                                        allow_parallel=allow_parallel)
 
     # -------------------------------------------------------------------------
     # Environment variables
@@ -3027,8 +3030,13 @@ def build_openssl(cfg: Config, target_platform: Platform) -> None:
             ])
 
         def runmake(command: str = "") -> None:
+            # Windows seems to have a problem building OpenSSL with
+            # nparallel > 1
+            allow_parallel = not BUILD_PLATFORM.windows
+
             run(cfg.make_args(command=command, env=env,
-                              extra_args=extra_args), env)
+                              extra_args=extra_args,
+                              allow_parallel=allow_parallel), env)
 
         # See INSTALL, INSTALL.WIN, etc. from the OpenSSL distribution
         runmake()

--- a/tablet_qt/tools/build_qt.py
+++ b/tablet_qt/tools/build_qt.py
@@ -166,7 +166,7 @@ Use of Python/library versions
 ==============================
 
 We don't rely on a standard CamCOPS Python virtual environment -- this makes it
-a bit easier to set things up for C++ work on Windows, for example. 
+a bit easier to set things up for C++ work on Windows, for example.
 
 
 Standard environment variables
@@ -512,7 +512,7 @@ DEFAULT_ANDROID_TOOLCHAIN_VERSION = "4.9"
 QT_GIT_URL = "git://code.qt.io/qt/qt5.git"
 QT_GIT_BRANCH = "5.12"  # is 5.12.4 as of 2019-06-18 (released 2019-06-17)
 QT_GIT_COMMIT = HEAD
-QT_SPECIFIC_VERSION = ""
+QT_SPECIFIC_VERSION = "5.12.11"
 
 if QT_SPECIFIC_VERSION:
     QT_VERSION = Version(QT_SPECIFIC_VERSION)
@@ -3068,7 +3068,7 @@ def fetch_qt(cfg: Config) -> None:
     run([PERL, "init-repository"])
     # Now, as per https://wiki.qt.io/Android:
     if QT_SPECIFIC_VERSION:
-        run([GIT, "checkout", QT_SPECIFIC_VERSION])
+        run([GIT, "checkout", f"v{QT_SPECIFIC_VERSION}"])
         run([GIT, "submodule", "update", "--recursive"])
 
 

--- a/tablet_qt/tools/build_qt.py
+++ b/tablet_qt/tools/build_qt.py
@@ -1625,14 +1625,8 @@ class Config(object):
         # Changed location from bitbucket:
         # https://gitlab.com/libeigen/eigen/-/archive/3.3.8/eigen-3.3.8.tar.gz
         self.eigen_version = EIGEN_VERSION  # type: str
-        # self.eigen_src_url = (
-        #     f"https://gitlab.com/libeigen/eigen/-/archive/{self.eigen_version}/eigen-{self.eigen_version}.tar.gz"  # noqa
-        # )
-
-        # TEMPORARY while GitLab restores the official repository
-        # https://gitlab.com/libeigen/eigen/-/issues/2336
         self.eigen_src_url = (
-            f"https://gitlab.com/cantonios/eigen/-/archive/{self.eigen_version}/eigen-{self.eigen_version}.tar.gz"  # noqa
+            f"https://gitlab.com/libeigen/eigen/-/archive/{self.eigen_version}/eigen-{self.eigen_version}.tar.gz"  # noqa
         )
 
         self.eigen_src_dir = join(self.src_rootdir, "eigen")

--- a/tablet_qt/tools/build_qt.py
+++ b/tablet_qt/tools/build_qt.py
@@ -1608,8 +1608,14 @@ class Config(object):
         # Changed location from bitbucket:
         # https://gitlab.com/libeigen/eigen/-/archive/3.3.8/eigen-3.3.8.tar.gz
         self.eigen_version = EIGEN_VERSION  # type: str
+        # self.eigen_src_url = (
+        #     f"https://gitlab.com/libeigen/eigen/-/archive/{self.eigen_version}/eigen-{self.eigen_version}.tar.gz"  # noqa
+        # )
+
+        # TEMPORARY while GitLab restores the official repository
+        # https://gitlab.com/libeigen/eigen/-/issues/2336
         self.eigen_src_url = (
-            f"https://gitlab.com/libeigen/eigen/-/archive/{self.eigen_version}/eigen-{self.eigen_version}.tar.gz"  # noqa
+            f"https://gitlab.com/cantonios/eigen/-/archive/{self.eigen_version}/eigen-{self.eigen_version}.tar.gz"  # noqa
         )
 
         self.eigen_src_dir = join(self.src_rootdir, "eigen")

--- a/tablet_qt/tools/build_qt.py
+++ b/tablet_qt/tools/build_qt.py
@@ -73,7 +73,8 @@ Status
 
 These OS combinations are reflected in the ``--build_all`` option.
 
-(*) May need ``--nparallel 1`` for the OpenSSL parts of the build.
+(*) Parallel compilation disabled by this script for the OpenSSL parts of the
+build.
 
 
 Why?


### PR DESCRIPTION
- Fixes #209 now OpenSSL is always built for static linking
- Fixes the MacOS build on Big Sur: the sysroot needs to point to the MacOS SDK path
- Disable parallel compilation on Windows for OpenSSL and force synchronized PDB writes (/FS) for 32-bit
- GitHub action to run the `build_qt.py` script on Linux whenever the script or the YAML config file changes
- Save some CO<sub>2</sub> by only running the server tests when server files change