### PR TITLE
Fix groups selector for non admin

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -3488,3 +3488,7 @@ Current C++/SQLite client, Python/SQLAlchemy server
 
 **Client and server v2.4.11, IN PROGRESS**
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Fix bug whereby non admin group members with the "manage patients" privilege
+  would see an empty group selector when adding/editing patients.
+  https://github.com/RudolfCardinal/camcops/issues/211

--- a/server/camcops_server/cc_modules/cc_forms.py
+++ b/server/camcops_server/cc_modules/cc_forms.py
@@ -1562,6 +1562,36 @@ class MandatoryGroupIdSelectorAdministeredGroups(SchemaNode, RequestAwareMixin):
         return Integer()
 
 
+class MandatoryGroupIdSelectorPatientGroups(SchemaNode, RequestAwareMixin):
+    """
+    Offers a picklist of groups the user can manage patients in.
+    Used when managing patients: "add patient to one of my groups".
+    """
+    def __init__(self, *args, **kwargs) -> None:
+        self.title = ""  # for type checker
+        self.validator = None  # type: Optional[ValidatorType]
+        self.widget = None  # type: Optional[Widget]
+        super().__init__(*args, **kwargs)
+
+    # noinspection PyUnusedLocal
+    def after_bind(self, node: SchemaNode, kw: Dict[str, Any]) -> None:
+        _ = self.gettext
+        self.title = _("Group")
+        request = self.request
+        dbsession = request.dbsession
+        group_ids = request.user.ids_of_groups_user_may_manage_patients_in
+        groups = dbsession.query(Group).order_by(Group.name)
+        values = [(g.id, g.name) for g in groups
+                  if g.id in group_ids]
+        values, pv = get_values_and_permissible(values)
+        self.widget = SelectWidget(values=values)
+        self.validator = OneOf(pv)
+
+    @staticmethod
+    def schema_type() -> SchemaType:
+        return Integer()
+
+
 class MandatoryGroupIdSelectorOtherGroups(SchemaNode, RequestAwareMixin):
     """
     Offers a picklist of groups THAT ARE NOT THE SPECIFIED GROUP (as specified
@@ -4171,7 +4201,7 @@ class DangerousEditPatientSchema(EditPatientSchema):
 
 class EditServerCreatedPatientSchema(EditPatientSchema):
     # Must match ViewParam.GROUP_ID
-    group_id = MandatoryGroupIdSelectorAdministeredGroups(
+    group_id = MandatoryGroupIdSelectorPatientGroups(
         insert_before="forename"
     )
     task_schedules = TaskScheduleSequence()  # must match ViewParam.TASK_SCHEDULES  # noqa: E501

--- a/server/camcops_server/cc_modules/tests/webview_tests.py
+++ b/server/camcops_server/cc_modules/tests/webview_tests.py
@@ -1571,6 +1571,25 @@ class AddPatientViewTests(DemoDatabaseTestCase):
             "Not authorized to manage patients"
         )
 
+    def test_group_listed_for_privileged_group_member(self) -> None:
+        user = self.create_user(username="testuser")
+        self.dbsession.flush()
+        self.create_membership(user, self.group, may_manage_patients=True)
+        self.dbsession.commit()
+
+        self.req._debugging_user = user
+
+        view = AddPatientView(self.req)
+
+        with mock.patch.object(view, "render_to_response") as mock_render:
+            view.dispatch()
+
+        args, kwargs = mock_render.call_args
+
+        context = args[0]
+
+        self.assertIn("testgroup", context["form"])
+
 
 class DeleteServerCreatedPatientViewTests(BasicDatabaseTestCase):
     """


### PR DESCRIPTION
Fixes  https://github.com/RudolfCardinal/camcops/issues/211
Non admin group members with the "manage patients" privilege would see an empty group selector when adding/editing patients.
